### PR TITLE
Subscription overload

### DIFF
--- a/src/Abc.Zebus.Tests/Core/BusTests.Subscribe.cs
+++ b/src/Abc.Zebus.Tests/Core/BusTests.Subscribe.cs
@@ -268,6 +268,26 @@ namespace Abc.Zebus.Tests.Core
         }
 
         [Test]
+        public void should_subscribe_to_single_subscription_with_untype_handler()
+        {
+            _bus.Start();
+
+            var invokers = new List<IMessageHandlerInvoker>();
+            _messageDispatcherMock.Setup(x => x.AddInvoker(It.IsAny<EventHandlerInvoker>())).Callback((IMessageHandlerInvoker i) => invokers.Add(i));
+
+            var handlerMock = new Mock<IMessageHandler<IMessage>>();
+            _bus.Subscribe(Subscription.Any<FakeEvent>(), handlerMock.Object.Handle);
+
+            invokers.Count.ShouldEqual(1);
+            invokers[0].CanInvokeSynchronously.ShouldBeTrue();
+            invokers[0].DispatchQueueName.ShouldEqual(DispatchQueueNameScanner.DefaultQueueName);
+            invokers[0].MessageHandlerType.ShouldNotBeNull();
+            invokers[0].MessageType.ShouldEqual(typeof(FakeEvent));
+            invokers[0].MessageTypeId.ShouldEqual(new MessageTypeId(typeof(FakeEvent)));
+            invokers[0].ShouldCreateStartedTasks.ShouldBeFalse();
+        }
+
+        [Test]
         public void should_unsubscribe_from_handler()
         {
             _bus.Start();

--- a/src/Abc.Zebus/Core/Bus.cs
+++ b/src/Abc.Zebus/Core/Bus.cs
@@ -277,17 +277,7 @@ namespace Abc.Zebus.Core
 
         public IDisposable Subscribe(Subscription subscription, Action<IMessage> handler)
         {
-            var eventHandlerInvoker = new EventHandlerInvoker(handler, subscription.MessageTypeId.GetMessageType());
-
-            _messageDispatcher.AddInvoker(eventHandlerInvoker);
-
-            AddSubscriptions(subscription);
-
-            return new DisposableAction(() =>
-            {
-                RemoveSubscriptions(subscription);
-                _messageDispatcher.RemoveInvoker(eventHandlerInvoker);
-            });
+            return Subscribe(new[] { subscription }, handler);
         }
 
         private void EnsureMessageHandlerInvokerExists(Subscription[] subscriptions)

--- a/src/Abc.Zebus/Core/MessageContextAwareBus.cs
+++ b/src/Abc.Zebus/Core/MessageContextAwareBus.cs
@@ -83,6 +83,11 @@ namespace Abc.Zebus.Core
             return _bus.Subscribe(subscriptions, handler);
         }
 
+        public IDisposable Subscribe(Subscription subscription, Action<IMessage> handler)
+        {
+            return _bus.Subscribe(subscription, handler);
+        }
+
         public void Reply(int errorCode)
         {
             MessageContext.ReplyCode = errorCode;

--- a/src/Abc.Zebus/IBus.cs
+++ b/src/Abc.Zebus/IBus.cs
@@ -20,6 +20,7 @@ namespace Abc.Zebus
         IDisposable Subscribe(Subscription[] subscriptions, SubscriptionOptions options = SubscriptionOptions.Default);
         IDisposable Subscribe<T>(Action<T> handler) where T : class, IMessage;
         IDisposable Subscribe(Subscription[] subscriptions, Action<IMessage> handler);
+        IDisposable Subscribe(Subscription subscription, Action<IMessage> handler);
 
         void Reply(int errorCode);
         void Reply(IMessage response);


### PR DESCRIPTION
I've added a new overload for the subscribe method that allow to pass only a single subscription (instead of an array).

```Csharp
IDisposable Subscribe(Subscription[] subscriptions, Action<IMessage> handler);

++ IDisposable Subscribe(Subscription subscription, Action<IMessage> handler);
```