### PR TITLE
Cleanup typesource

### DIFF
--- a/src/Abc.Zebus.Tests/Util/TypeUtilTests.cs
+++ b/src/Abc.Zebus.Tests/Util/TypeUtilTests.cs
@@ -1,4 +1,5 @@
-﻿using Abc.Zebus.Testing.Extensions;
+﻿using System.Reflection;
+using Abc.Zebus.Testing.Extensions;
 using Abc.Zebus.Util;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
@@ -24,6 +25,9 @@ namespace Abc.Zebus.Tests.Util
         [Test]
         public void should_resolve_type_from_exe_assembly()
         {
+            // we have to ensure that the .exe is loaded in the current AppDomain
+            Assembly.LoadFile(PathUtil.InBaseDirectory("Abc.Zebus.Tests.TestExe.exe"));
+
             Assert.That(TypeUtil.Resolve("Abc.Zebus.Tests.TestExe.Program"), Is.Not.Null);
         }
 

--- a/src/Abc.Zebus/Scan/TypeSource.cs
+++ b/src/Abc.Zebus/Scan/TypeSource.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Abc.Zebus.Util;
 
 namespace Abc.Zebus.Scan
 {
@@ -19,14 +18,7 @@ namespace Abc.Zebus.Scan
 
         public virtual IEnumerable<Type> GetTypes()
         {
-            return GetTargetAssemblies().Where(AssemblyFilter).SelectMany(x => x.GetTypes()).Where(TypeFilter);
-        }
-
-        private static IEnumerable<Assembly> GetTargetAssemblies()
-        {
-            TypeUtil.EnsureAbcAssembliesAreLoaded();
-
-            return AppDomain.CurrentDomain.GetAssemblies();
+            return AppDomain.CurrentDomain.GetAssemblies().Where(AssemblyFilter).SelectMany(x => x.GetTypes()).Where(TypeFilter);
         }
 
         public static implicit operator TypeSource(Type type)

--- a/src/Abc.Zebus/Util/TypeUtil.cs
+++ b/src/Abc.Zebus/Util/TypeUtil.cs
@@ -3,26 +3,18 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using log4net;
 
 namespace Abc.Zebus.Util
 {
     internal static class TypeUtil
     {
-        private static readonly ILog _logger = LogManager.GetLogger(typeof(TypeUtil));
         private static readonly ConcurrentDictionary<string, Type> _typesByNames = new ConcurrentDictionary<string, Type>();
 
         public static Type Resolve(string typeName)
         {
             return _typesByNames.GetOrAdd(typeName, FindTypeByName);
         }
-
-        public static void EnsureAbcAssembliesAreLoaded()
-        {
-            AssemblyLoader.EnsureAbcAssembliesAreLoaded();
-        }
-
+        
         private static Type FindTypeByName(string typeName)
         {
             try
@@ -35,12 +27,9 @@ namespace Abc.Zebus.Util
             {
             }
 
-            AssemblyLoader.EnsureAbcAssembliesAreLoaded();
-
             if (typeName.Contains("<"))
                 return FindGenericTypeByName(typeName);
             
-            // OrderBy(a => a.FullName) because 99% of requested types will be in Abc assemblies
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().OrderBy(a => a.FullName))
             {
                 var type = assembly.GetType(typeName);
@@ -53,7 +42,7 @@ namespace Abc.Zebus.Util
 
         private static Type FindGenericTypeByName(string typeName)
         {
-            var genericArguments = typeName.Substring(typeName.IndexOf("<", System.StringComparison.Ordinal)).Trim('<', '>').Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            var genericArguments = typeName.Substring(typeName.IndexOf("<", StringComparison.Ordinal)).Trim('<', '>').Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             var typeNameWithoutGenericArguments = typeName.Substring(0, typeName.IndexOf("<", StringComparison.Ordinal)) + '`' + genericArguments.Length;
 
 
@@ -70,35 +59,6 @@ namespace Abc.Zebus.Util
                 genericTypes.Add(genericType);
             }
             return type.MakeGenericType(genericTypes.ToArray());
-        }
-
-        private static class AssemblyLoader
-        {
-            static AssemblyLoader()
-            {
-                LoadAssemblies("dll");
-                LoadAssemblies("exe");
-            }
-
-            private static void LoadAssemblies(string extension)
-            {
-                foreach (var assemblyPath in System.IO.Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "Abc.*." + extension))
-                {
-                    var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
-                    try
-                    {
-                        Assembly.Load(assemblyName);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.WarnFormat("Unable to load assembly {0}: {1}", assemblyName, ex);
-                    }
-                }
-            }
-
-            public static void EnsureAbcAssembliesAreLoaded()
-            {
-            }
         }
     }
 }


### PR DESCRIPTION
I've just removed some code. Like I said on the issue #36.

The loading of assemblies in the current AppDomain should be the responsibility of the client code, not the bus.