### PR TITLE
Response message string + C# 6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 version: 1.2.{build}
+os: Visual Studio 2015
 before_build:
-- nuget restore src/Abc.Zebus.sln
+- cmd: nuget restore src/Abc.Zebus.sln
 build:
   verbosity: minimal
 test:

--- a/build/Zebus.build
+++ b/build/Zebus.build
@@ -12,11 +12,14 @@
 	<property name="artefacts.dir" value="${output.dir}\artefacts" />
 	<property name="src.dir" value="${directory::get-current-directory()}\src" />
 	<property name="nunit.result.dir" value="${artefacts.dir}\nunit" />
-	<property name="msbuild.exe" value="C:\WINDOWS\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"/>
 	<property name="nunit.dir" value='tools\nunit' />
 	<property name="nunit.exe" value='${nunit.dir}\nunit-console.exe' />
 	<property name="nuget.exe" value='tools\nuget\NuGet.exe' /> 
 	
+	<property name="msbuild.exe" value="?" />
+	<readregistry property="msbuild.exe" hive="LocalMachine" key="SOFTWARE\Microsoft\MSBuild\ToolsVersions\14.0\MSBuildToolsPath" failonerror="false" if="${msbuild.exe == '?'}" />
+	<property name="msbuild.exe" value="C:\WINDOWS\Microsoft.NET\Framework\v4.0.30319" if="${msbuild.exe == '?'}" />
+	<property name="msbuild.exe" value="${path::combine(msbuild.exe, 'msbuild.exe')}" />
 	
 	<target name="build-tc" depends="init init-project nuget-restore compile-tests compile"/>
 	<target name="build-local" depends="init init-project nuget-restore compile compile-tests test localonly-test"/>

--- a/src/Abc.Zebus.Tests/CommandResultTests.cs
+++ b/src/Abc.Zebus.Tests/CommandResultTests.cs
@@ -10,6 +10,7 @@ namespace Abc.Zebus.Tests
         {
             [System.ComponentModel.Description("This is a fake error message")]
             SomeErrorValue = 1,
+
             [System.ComponentModel.Description("This is a fake {0} error message")]
             SomeErrorValueWithFormat = 2,
             NoDescriptionErrorValue = 3
@@ -18,7 +19,7 @@ namespace Abc.Zebus.Tests
         [Test]
         public void should_retrieve_empty_error_message_from_command_result_with_no_error()
         {
-            var cmdResult = new CommandResult(0, null);
+            var cmdResult = new CommandResult(0, null, null);
 
             cmdResult.GetErrorMessageFromEnum<FakeEnumErrorCode>().ShouldBeEmpty();
         }
@@ -26,7 +27,7 @@ namespace Abc.Zebus.Tests
         [Test]
         public void should_retrieve_error_message_from_command_result_with_enum_description()
         {
-            var cmdResult = new CommandResult((int)FakeEnumErrorCode.SomeErrorValue, null);
+            var cmdResult = new CommandResult((int)FakeEnumErrorCode.SomeErrorValue, null, null);
 
             cmdResult.GetErrorMessageFromEnum<FakeEnumErrorCode>().ShouldEqual("This is a fake error message");
         }
@@ -34,7 +35,7 @@ namespace Abc.Zebus.Tests
         [Test]
         public void should_retrieve_error_message_from_command_result_with_enum_description_and_format()
         {
-            var cmdResult = new CommandResult((int)FakeEnumErrorCode.SomeErrorValueWithFormat, null);
+            var cmdResult = new CommandResult((int)FakeEnumErrorCode.SomeErrorValueWithFormat, null, null);
 
             cmdResult.GetErrorMessageFromEnum<FakeEnumErrorCode>("formated").ShouldEqual("This is a fake formated error message");
         }
@@ -42,7 +43,7 @@ namespace Abc.Zebus.Tests
         [Test]
         public void should_retrieve_empty_error_message_from_command_result_with_enum_no_description()
         {
-            var cmdResult = new CommandResult((int)FakeEnumErrorCode.NoDescriptionErrorValue, null);
+            var cmdResult = new CommandResult((int)FakeEnumErrorCode.NoDescriptionErrorValue, null, null);
 
             cmdResult.GetErrorMessageFromEnum<FakeEnumErrorCode>().ShouldBeEmpty();
         }

--- a/src/Abc.Zebus.Tests/Persistence/PersistentTransportTests.cs
+++ b/src/Abc.Zebus.Tests/Persistence/PersistentTransportTests.cs
@@ -180,7 +180,7 @@ namespace Abc.Zebus.Tests.Persistence
         [Test]
         public void should_handle_execution_completion_received()
         {
-            var messageExecutionCompletedTransportMessage = new MessageExecutionCompleted(MessageId.NextId(), 0).ToTransportMessage();
+            var messageExecutionCompletedTransportMessage = new MessageExecutionCompleted(MessageId.NextId(), 0, null).ToTransportMessage();
 
             InnerTransport.RaiseMessageReceived(messageExecutionCompletedTransportMessage);
 

--- a/src/Abc.Zebus.sln
+++ b/src/Abc.Zebus.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Abc.Zebus", "Abc.Zebus\Abc.Zebus.csproj", "{1F4C6307-6113-40D5-BF42-4B6BF5DF13B2}"
 EndProject

--- a/src/Abc.Zebus/Abc.Zebus.csproj
+++ b/src/Abc.Zebus/Abc.Zebus.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Dispatch\IMessageDispatchFactory.cs" />
     <Compile Include="Dispatch\IMessageHandlerInvocation.cs" />
     <Compile Include="BusExtensions.cs" />
+    <Compile Include="ErrorStatus.cs" />
     <Compile Include="Hosting\HostInitializer.cs" />
     <Compile Include="Hosting\HostInitializerHelper.cs" />
     <Compile Include="Hosting\PeriodicActionHostInitializer.cs" />

--- a/src/Abc.Zebus/Core/MessageContextAwareBus.cs
+++ b/src/Abc.Zebus/Core/MessageContextAwareBus.cs
@@ -14,30 +14,12 @@ namespace Abc.Zebus.Core
             MessageContext = messageContext;
         }
 
-        public IBus InnerBus
-        {
-            get { return _bus; }
-        }
+        public IBus InnerBus => _bus;
+        public PeerId PeerId => _bus.PeerId;
+        public string Environment => _bus.Environment;
+        public bool IsRunning => _bus.IsRunning;
 
-        public PeerId PeerId
-        {
-            get { return _bus.PeerId; }
-        }
-
-        public string Environment
-        {
-            get { return _bus.Environment; }
-        }
-
-        public bool IsRunning
-        {
-            get { return _bus.IsRunning; }
-        }
-
-        public void Configure(PeerId peerId, string environment)
-        {
-            _bus.Configure(peerId, environment);
-        }
+        public void Configure(PeerId peerId, string environment) => _bus.Configure(peerId, environment);
 
         public void Publish(IEvent message)
         {
@@ -64,33 +46,26 @@ namespace Abc.Zebus.Core
         }
 
         public IDisposable Subscribe(Subscription subscription, SubscriptionOptions options = SubscriptionOptions.Default)
-        {
-            return _bus.Subscribe(subscription);
-        }
+            => _bus.Subscribe(subscription);
 
         public IDisposable Subscribe(Subscription[] subscriptions, SubscriptionOptions options = SubscriptionOptions.Default)
-        {
-            return _bus.Subscribe(subscriptions);
-        }
+            => _bus.Subscribe(subscriptions);
 
         public IDisposable Subscribe<T>(Action<T> handler) where T : class, IMessage
-        {
-            return _bus.Subscribe(handler);
-        }
+            => _bus.Subscribe(handler);
 
         public IDisposable Subscribe(Subscription[] subscriptions, Action<IMessage> handler)
-        {
-            return _bus.Subscribe(subscriptions, handler);
-        }
+            => _bus.Subscribe(subscriptions, handler);
 
         public IDisposable Subscribe(Subscription subscription, Action<IMessage> handler)
-        {
-            return _bus.Subscribe(subscription, handler);
-        }
+            => _bus.Subscribe(subscription, handler);
 
-        public void Reply(int errorCode)
+        public void Reply(int errorCode) => Reply(errorCode, null);
+
+        public void Reply(int errorCode, string message)
         {
             MessageContext.ReplyCode = errorCode;
+            MessageContext.ReplyMessage = message;
         }
 
         public void Reply(IMessage response)
@@ -98,16 +73,8 @@ namespace Abc.Zebus.Core
             MessageContext.ReplyResponse = response;
         }
 
-        public void Start()
-        {
-            _bus.Start();
-        }
-
-        public void Stop()
-        {
-            _bus.Stop();
-        }
-
+        public void Start() => _bus.Start();
+        public void Stop() => _bus.Stop();
 
         public event Action Starting
         {
@@ -131,9 +98,6 @@ namespace Abc.Zebus.Core
             remove { _bus.Stopped -= value; }
         }
 
-        public void Dispose()
-        {
-            _bus.Dispose();
-        }
+        public void Dispose() => _bus.Dispose();
     }
 }

--- a/src/Abc.Zebus/ErrorStatus.cs
+++ b/src/Abc.Zebus/ErrorStatus.cs
@@ -1,0 +1,23 @@
+using Abc.Zebus.Util.Annotations;
+
+namespace Abc.Zebus
+{
+    internal class ErrorStatus
+    {
+        public static readonly ErrorStatus NoError = new ErrorStatus(0, null);
+        public static readonly ErrorStatus UnknownError = new ErrorStatus(1, null);
+
+        public int Code { get; }
+
+        [CanBeNull]
+        public string Message { get; }
+
+        public ErrorStatus(int code, string message)
+        {
+            Code = code;
+            Message = message;
+        }
+
+        public override string ToString() => $"{Code}: {Message}";
+    }
+}

--- a/src/Abc.Zebus/IBus.cs
+++ b/src/Abc.Zebus/IBus.cs
@@ -23,6 +23,7 @@ namespace Abc.Zebus
         IDisposable Subscribe(Subscription subscription, Action<IMessage> handler);
 
         void Reply(int errorCode);
+        void Reply(int errorCode, string message);
         void Reply(IMessage response);
         
         void Start();


### PR DESCRIPTION
This PR adds an optional response message in addition to the existing error code.

This would enable us to:
 - send more detailed error messages
 - display meaningful error messages for replies with unexpected error codes (due to a newer version for instance)

It also adds C# 6 support.

Please review.