### PR TITLE
Configuration setting for directory peer id

### DIFF
--- a/src/Abc.Zebus.Tests/Directory/PeerDirectoryClientTests.cs
+++ b/src/Abc.Zebus.Tests/Directory/PeerDirectoryClientTests.cs
@@ -31,6 +31,7 @@ namespace Abc.Zebus.Tests.Directory
         public void Setup()
         {
             _configurationMock = new Mock<IBusConfiguration>();
+            _configurationMock.SetupGet(x => x.DirectoryServicePeerIdPrefix).Returns("The.Directory");
             _configurationMock.SetupGet(x => x.DirectoryServiceEndPoints).Returns(new[] { "tcp://main-directory:777", "tcp://backup-directory:777" });
             _configurationMock.SetupGet(x => x.RegistrationTimeout).Returns(200.Milliseconds());
             _configurationMock.SetupGet(x => x.IsDirectoryPickedRandomly).Returns(false);
@@ -53,7 +54,7 @@ namespace Abc.Zebus.Tests.Directory
             {
                 _directory.Register(_bus, _self, subscriptions);
 
-                var expectedRecipientId = new PeerId("Abc.Zebus.DirectoryService.0");
+                var expectedRecipientId = new PeerId("The.Directory.0");
                 _bus.Commands.Count().ShouldEqual(1);
 
                 var register = _bus.Commands.OfType<RegisterPeerCommand>().ExpectedSingle();
@@ -439,12 +440,12 @@ namespace Abc.Zebus.Tests.Directory
         public void should_connect_to_next_directory_if_first_is_failing()
         {
             _bus.HandlerExecutor = new TestBus.AsyncHandlerExecutor();
-            _bus.AddHandlerForPeer<RegisterPeerCommand>(new PeerId("Abc.Zebus.DirectoryService.0"), x =>
+            _bus.AddHandlerForPeer<RegisterPeerCommand>(new PeerId("The.Directory.0"), x =>
             {
                 Thread.Sleep(1.Second());
                 return new RegisterPeerResponse(new PeerDescriptor[0]);
             });
-            _bus.AddHandlerForPeer<RegisterPeerCommand>(new PeerId("Abc.Zebus.DirectoryService.1"), x =>
+            _bus.AddHandlerForPeer<RegisterPeerCommand>(new PeerId("The.Directory.1"), x =>
             {
                 return new RegisterPeerResponse(new PeerDescriptor[0]);
             });
@@ -454,8 +455,8 @@ namespace Abc.Zebus.Tests.Directory
 
             var contactedPeers = _bus.GetContactedPeerIds().ToList();
             contactedPeers.Count.ShouldEqual(2);
-            contactedPeers.ShouldContain(new PeerId("Abc.Zebus.DirectoryService.0"));
-            contactedPeers.ShouldContain(new PeerId("Abc.Zebus.DirectoryService.1"));
+            contactedPeers.ShouldContain(new PeerId("The.Directory.0"));
+            contactedPeers.ShouldContain(new PeerId("The.Directory.1"));
         }
 
         [Test]

--- a/src/Abc.Zebus/Core/BusFactory.cs
+++ b/src/Abc.Zebus/Core/BusFactory.cs
@@ -41,7 +41,13 @@ namespace Abc.Zebus.Core
         public BusFactory WithConfiguration(string directoryEndPoints, string environment)
         {
             var endpoints = directoryEndPoints.Split(new[] { ' ', ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
-            return WithConfiguration(new BusConfiguration(endpoints), environment);
+            return WithConfiguration(new BusConfiguration(endpoints, "Abc.Zebus.DirectoryService."), environment);
+        }
+
+        public BusFactory WithConfiguration(string directoryEndPoints, string directoryServicePeerIdPrefix, string environment)
+        {
+            var endpoints = directoryEndPoints.Split(new[] { ' ', ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
+            return WithConfiguration(new BusConfiguration(endpoints, directoryServicePeerIdPrefix), environment);
         }
 
         public BusFactory WithConfiguration(IBusConfiguration configuration, string environment)
@@ -129,12 +135,14 @@ namespace Abc.Zebus.Core
 
         private class BusConfiguration : IBusConfiguration
         {
-            public BusConfiguration(params string[] directoryServiceEndPoints)
+            public BusConfiguration(string[] directoryServiceEndPoints, string directoryServicePeerIdPrefix)
             {
                 DirectoryServiceEndPoints = directoryServiceEndPoints;
+                DirectoryServicePeerIdPrefix = directoryServicePeerIdPrefix;
                 RegistrationTimeout = 10.Second();
             }
 
+            public string DirectoryServicePeerIdPrefix { get; }
             public string[] DirectoryServiceEndPoints { get; }
             public TimeSpan RegistrationTimeout { get; }
             public TimeSpan StartReplayTimeout => 30.Seconds();

--- a/src/Abc.Zebus/Directory/PeerDirectoryClient.cs
+++ b/src/Abc.Zebus/Directory/PeerDirectoryClient.cs
@@ -157,13 +157,21 @@ namespace Abc.Zebus.Directory
         // Only internal for testing purposes
         internal IEnumerable<Peer> GetDirectoryPeers()
         {
-            _directoryPeers = _configuration.DirectoryServiceEndPoints.Select(CreateDirectoryPeer);
+            var directoryPeerIdPrefix = EnsureTrailingDot(_configuration.DirectoryServicePeerIdPrefix);
+            _directoryPeers = _configuration.DirectoryServiceEndPoints.Select( (endpoint, index) => CreateDirectoryPeer(directoryPeerIdPrefix, endpoint, index));
             return _configuration.IsDirectoryPickedRandomly ? _directoryPeers.Shuffle() : _directoryPeers;
         }
 
-        private static Peer CreateDirectoryPeer(string endPoint, int index)
+        private string EnsureTrailingDot(string directoryServicePeerIdPrefix)
         {
-            var peerId = new PeerId("Abc.Zebus.DirectoryService." + index);
+            return directoryServicePeerIdPrefix.EndsWith(".")
+                ? directoryServicePeerIdPrefix
+                : directoryServicePeerIdPrefix + ".";
+        }
+
+        private static Peer CreateDirectoryPeer(string directoryPeerIdPrefix, string endPoint, int index)
+        {
+            var peerId = new PeerId(directoryPeerIdPrefix + index);
             return new Peer(peerId, endPoint);
         }
 

--- a/src/Abc.Zebus/IBusConfiguration.cs
+++ b/src/Abc.Zebus/IBusConfiguration.cs
@@ -6,6 +6,12 @@ namespace Abc.Zebus
     public interface IBusConfiguration
     {
         /// <summary>
+        /// Prefix used to create directories peer ids.
+        /// Expected to be something like "Some.Peer." or "Some.Peer".
+        /// </summary>
+        string DirectoryServicePeerIdPrefix { get; }
+
+        /// <summary>
         /// The list of directories that can be used by the Bus to register.
         /// The syntax is "tcp://hostname:port"
         /// </summary>


### PR DESCRIPTION
I've added a new configuration property in IBusConfiguration in order to choose a prefix for the directory peer ids. 

It's obviously a breaking change since a new property just popped in an interface that every user should have already implemented. We can throw this PR away if you have a better idea (without any breaking changes ?)