### PR TITLE
Replace dedicated thread in PeriodicActionHostInitializer by a System.Threading.Timer

### DIFF
--- a/src/Abc.Zebus.Tests/Util/SystemDateTimeTests.cs
+++ b/src/Abc.Zebus.Tests/Util/SystemDateTimeTests.cs
@@ -14,11 +14,11 @@ namespace Abc.Zebus.Tests.Util
         {
             var dateTimeUtcNow = DateTime.UtcNow;
             var sysDateTimeUtcNow = SystemDateTime.UtcNow;
-            sysDateTimeUtcNow.Subtract(dateTimeUtcNow).ShouldBeLessOrEqualThan(2.Milliseconds());
+            sysDateTimeUtcNow.Subtract(dateTimeUtcNow).ShouldBeLessOrEqualThan(10.Milliseconds());
 
             var dateTimeNow = DateTime.Now;
             var sysDateTimeNow = SystemDateTime.Now;
-            sysDateTimeNow.Subtract(dateTimeNow).ShouldBeLessOrEqualThan(2.Milliseconds());
+            sysDateTimeNow.Subtract(dateTimeNow).ShouldBeLessOrEqualThan(10.Milliseconds());
         }
 
         [Test]


### PR DESCRIPTION
No more dedicated thread, now each `PeriodicActionHostInitializer ` uses an internal timer.

It's basically the same things as before, the only notable change is that the periodic action code can now be executed by different threads (from the threadpool). But at least the periodic action invoker makes sure there is no multiple executions at the same time if the periodic action takes to much time (see test `should_not_execute_action_multiple_times_from_multiple_threads_if_actions_takes_too_long`).
I know there is [an other way to handle the concurrent executions problem](http://stackoverflow.com/questions/684200/synchronizing-a-timer-to-prevent-overlap) by using the timer without a period but only with a due time but I found this solution a bit ugly and complicated (the code would be a bit clunky IMO).
The issue with the implem I made is that if the periodic action is not finished within the given period we will have to wait for another full period to retry ... which is a good thing I guess. And we won a log showing that the periodic action is taking too much time (could already happen without knowing I think)