### PR TITLE
Reduce serializations 

### DIFF
--- a/src/Abc.Zebus.Testing/TestExtensions.cs
+++ b/src/Abc.Zebus.Testing/TestExtensions.cs
@@ -27,9 +27,9 @@ namespace Abc.Zebus.Testing
             return new TransportMessage(message.TypeId(), content, sender) { WasPersisted = wasPersisted };
         }
 
-        public static TransportMessage WithPersistentPeerIds(this TransportMessage transportMessage, params PeerId[] peerIds)
+        public static TransportMessage ToPersistTransportMessage(this TransportMessage transportMessage, params PeerId[] peerIds)
         {
-            return transportMessage.WithPersistentPeerIds(peerIds.ToList());
+            return transportMessage.ToPersistTransportMessage(peerIds.ToList());
         }
 
         public static IMessage ToMessage(this TransportMessage transportMessage)

--- a/src/Abc.Zebus.Testing/TestExtensions.cs
+++ b/src/Abc.Zebus.Testing/TestExtensions.cs
@@ -27,6 +27,11 @@ namespace Abc.Zebus.Testing
             return new TransportMessage(message.TypeId(), content, sender) { WasPersisted = wasPersisted };
         }
 
+        public static TransportMessage WithPersistentPeerIds(this TransportMessage transportMessage, params PeerId[] peerIds)
+        {
+            return transportMessage.WithPersistentPeerIds(peerIds.ToList());
+        }
+
         public static IMessage ToMessage(this TransportMessage transportMessage)
         {
             var serializer = new MessageSerializer();

--- a/src/Abc.Zebus.Testing/Transport/TestTransport.cs
+++ b/src/Abc.Zebus.Testing/Transport/TestTransport.cs
@@ -81,7 +81,7 @@ namespace Abc.Zebus.Testing.Transport
         public void Send(TransportMessage message, IEnumerable<Peer> peers, SendContext context)
         {
             var peerList = peers.ToList();
-            if (peerList.Any())
+            if (peerList.Any() || context.PersistencePeer != null)
                 _messages.Add(new TransportMessageSent(message, peerList, context));
 
             var deserializedMessage = _messageSerializer.Deserialize(message.MessageTypeId, message.Content);

--- a/src/Abc.Zebus.Testing/Transport/TestTransport.cs
+++ b/src/Abc.Zebus.Testing/Transport/TestTransport.cs
@@ -96,7 +96,7 @@ namespace Abc.Zebus.Testing.Transport
 
         public TransportMessage CreateInfrastructureTransportMessage(MessageTypeId messageTypeId)
         {
-            return new TransportMessage(messageTypeId, new MemoryStream(), PeerId, InboundEndPoint, MessageId.NextId());
+            return new TransportMessage(messageTypeId, new MemoryStream(), PeerId, InboundEndPoint);
         }
 
         public void RaiseMessageReceived(TransportMessage transportMessage)

--- a/src/Abc.Zebus.Testing/Transport/TransportMessageSent.cs
+++ b/src/Abc.Zebus.Testing/Transport/TransportMessageSent.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Abc.Zebus.Transport;
 
@@ -39,6 +40,18 @@ namespace Abc.Zebus.Testing.Transport
             if (wasPersistent)
                 Context.PersistentPeerIds.Add(peer.Id);
 
+            return this;
+        }
+
+        public TransportMessageSent ToPersistence(Peer persistencePeer)
+        {
+            Context.PersistencePeer = persistencePeer;
+            return this;
+        }
+
+        public TransportMessageSent AddPersistentPeer(Peer peer)
+        {
+            Context.PersistentPeerIds.Add(peer.Id);
             return this;
         }
     }

--- a/src/Abc.Zebus.Testing/Transport/TransportMessageSent.cs
+++ b/src/Abc.Zebus.Testing/Transport/TransportMessageSent.cs
@@ -37,7 +37,7 @@ namespace Abc.Zebus.Testing.Transport
         {
             Targets.Add(peer);
             if (wasPersistent)
-                Context.PersistedPeerIds.Add(peer.Id);
+                Context.PersistentPeerIds.Add(peer.Id);
 
             return this;
         }

--- a/src/Abc.Zebus.Tests/Abc.Zebus.Tests.csproj
+++ b/src/Abc.Zebus.Tests/Abc.Zebus.Tests.csproj
@@ -183,6 +183,7 @@
     <Compile Include="Dispatch\DispatchMessages\ScanCommandHandler2.cs" />
     <Compile Include="SerializationTests.cs" />
     <Compile Include="Directory\PeerSubscriptionTreeTests.cs" />
+    <Compile Include="Serialization\MessageSerializerTests.cs" />
     <Compile Include="Serialization\TestMessageSerializer.cs" />
     <Compile Include="SubscriptionTests.cs" />
     <Compile Include="SubscriptionTests.Legacy.cs" />

--- a/src/Abc.Zebus.Tests/Core/BusTests.CompletionMessages.cs
+++ b/src/Abc.Zebus.Tests/Core/BusTests.CompletionMessages.cs
@@ -120,13 +120,13 @@ namespace Abc.Zebus.Tests.Core
                         _transport.RaiseMessageReceived(commandCompleted.ToTransportMessage());
                     });
 
-                    var getThreadIdTask = GetThreadIfAfterAwaitingCommandResult(task);
+                    var getThreadIdTask = GetThreadIdAfterAwaitingCommandResult(task);
 
                     getThreadIdTask.Result.ShouldNotEqual(backgroundThreadId);
                 }
             }
 
-            private async Task<int> GetThreadIfAfterAwaitingCommandResult(Task<CommandResult> task)
+            private async Task<int> GetThreadIdAfterAwaitingCommandResult(Task<CommandResult> task)
             {
                 await task;
                 return Thread.CurrentThread.ManagedThreadId;

--- a/src/Abc.Zebus.Tests/Core/BusTests.cs
+++ b/src/Abc.Zebus.Tests/Core/BusTests.cs
@@ -8,13 +8,12 @@ using Abc.Zebus.Testing.Comparison;
 using Abc.Zebus.Testing.Dispatch;
 using Abc.Zebus.Testing.Transport;
 using Abc.Zebus.Tests.Serialization;
-using Abc.Zebus.Util;
 using Moq;
 using NUnit.Framework;
 
 namespace Abc.Zebus.Tests.Core
 {
-    [TestFixture]
+    [TestFixture, Timeout(20000)]
     public abstract partial class BusTests
     {
         private const string _environment = "Test";

--- a/src/Abc.Zebus.Tests/Log4netConfigurator.cs
+++ b/src/Abc.Zebus.Tests/Log4netConfigurator.cs
@@ -15,7 +15,7 @@ namespace Abc.Zebus.Tests
         public void Setup()
         {
             var configurationFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "log4net.config");
-            //XmlConfigurator.Configure(new FileInfo(configurationFile));
+            XmlConfigurator.Configure(new FileInfo(configurationFile));
         }
 
         [UsedImplicitly]

--- a/src/Abc.Zebus.Tests/Persistence/PersistentTransportFixture.cs
+++ b/src/Abc.Zebus.Tests/Persistence/PersistentTransportFixture.cs
@@ -44,6 +44,7 @@ namespace Abc.Zebus.Tests.Persistence
             configuration.Setup(x => x.StartReplayTimeout).Returns(TimeSpan.FromMinutes(60));
 
             PeerDirectory = new Mock<IPeerDirectory>();
+            PeerDirectory.Setup(dir => dir.GetPeersHandlingMessage(MessageBinding.Default<PersistMessageCommand>())).Returns(new[] { PersistencePeer });
             PeerDirectory.Setup(dir => dir.GetPeersHandlingMessage(It.IsAny<StartMessageReplayCommand>())).Returns(new[] { PersistencePeer });
             PeerDirectory.Setup(dir => dir.GetPeersHandlingMessage(It.IsAny<PersistMessageCommand>())).Returns(new[] { PersistencePeer });
             PeerDirectory.Setup(dir => dir.GetPeersHandlingMessage(It.IsAny<MessageHandled>())).Returns(new[] { PersistencePeer });

--- a/src/Abc.Zebus.Tests/Persistence/PersistentTransportTests.cs
+++ b/src/Abc.Zebus.Tests/Persistence/PersistentTransportTests.cs
@@ -207,7 +207,7 @@ namespace Abc.Zebus.Tests.Persistence
 
                 Transport.Send(message, new[] { AnotherPersistentPeer });
 
-                var expectedPersistenceMessage = new PersistMessageCommand(message, new[] { AnotherPersistentPeer.Id }).ToTransportMessage(Self);
+                var expectedPersistenceMessage = message.WithPersistentPeerIds(AnotherPersistentPeer.Id);
                 InnerTransport.ExpectExactly(new[]
                 {
                     new TransportMessageSent(message, AnotherPersistentPeer, true),
@@ -226,7 +226,7 @@ namespace Abc.Zebus.Tests.Persistence
 
                 Transport.Send(message, new[] { downPeer });
 
-                InnerTransport.ExpectExactly(new TransportMessageSent(new PersistMessageCommand(message, new[] { downPeer.Id }).ToTransportMessage(Self), new[] { PersistencePeer }));
+                InnerTransport.ExpectExactly(new TransportMessageSent(message.WithPersistentPeerIds(downPeer.Id), new[] { PersistencePeer }));
             }
         }
 
@@ -249,14 +249,13 @@ namespace Abc.Zebus.Tests.Persistence
             using (MessageId.PauseIdGeneration())
             {
                 var message = new FakeEvent(123).ToTransportMessage(Self);
-                var persistenceCommand = new PersistMessageCommand(message, new[] { AnotherPersistentPeer.Id }).ToTransportMessage(Self);
 
                 Transport.Send(message, new[] { AnotherPersistentPeer, AnotherNonPersistentPeer });
 
                 InnerTransport.ExpectExactly(new []
                 {
                     new TransportMessageSent(message).To(AnotherPersistentPeer, true).To(AnotherNonPersistentPeer, false),
-                    new TransportMessageSent(persistenceCommand, PersistencePeer),
+                    new TransportMessageSent(message.WithPersistentPeerIds(AnotherPersistentPeer.Id), PersistencePeer),
                 });
             }
         }
@@ -358,10 +357,9 @@ namespace Abc.Zebus.Tests.Persistence
 
                 InnerTransport.ExpectExactly(new[]
                 {
-                    new TransportMessageSent(new PersistMessageCommand(message, new[] { AnotherPersistentPeer.Id }).ToTransportMessage(Self), PersistencePeer),
+                    new TransportMessageSent(message.WithPersistentPeerIds(AnotherPersistentPeer.Id), PersistencePeer),
                     new TransportMessageSent(new MessageHandled(ackedMessage.Id).ToTransportMessage(Self), PersistencePeer)
                 });
-
 
                 InnerTransport.Messages.Clear();
                 InnerTransport.AckedMessages.Clear();
@@ -373,7 +371,7 @@ namespace Abc.Zebus.Tests.Persistence
                 InnerTransport.ExpectExactly(new[]
                 {
                     new TransportMessageSent(message, AnotherPersistentPeer, true),
-                    new TransportMessageSent(new PersistMessageCommand(message, new[] { AnotherPersistentPeer.Id }).ToTransportMessage(Self), PersistencePeer),
+                    new TransportMessageSent(message.WithPersistentPeerIds(AnotherPersistentPeer.Id), PersistencePeer),
                     new TransportMessageSent(new MessageHandled(ackedMessage.Id).ToTransportMessage(Self), PersistencePeer),
                 });
             }

--- a/src/Abc.Zebus.Tests/Serialization/MessageSerializerTests.cs
+++ b/src/Abc.Zebus.Tests/Serialization/MessageSerializerTests.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using Abc.Zebus.Persistence;
+using Abc.Zebus.Serialization;
+using Abc.Zebus.Testing;
+using Abc.Zebus.Testing.Extensions;
+using Abc.Zebus.Tests.Messages;
+using NUnit.Framework;
+
+namespace Abc.Zebus.Tests.Serialization
+{
+    [TestFixture]
+    public class MessageSerializerTests
+    {
+        private MessageSerializer _messageSerializer;
+        private Peer _self;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _messageSerializer = new MessageSerializer();
+            _self = new Peer(new PeerId("Abc.Testing.Self"), "tcp://testing:123");
+        }
+
+        [Test]
+        public void should_serialize_persist_message_command()
+        {
+            var transportMessage = new FakeEvent(42).ToTransportMessage(_self);
+            var persistMessageCommand = new PersistMessageCommand(transportMessage, new PeerId("Abc.Testing.A"), new PeerId("Abc.Testing.B"));
+
+            var serializedTransportMessage = _messageSerializer.ToTransportMessage(persistMessageCommand, _self.Id, _self.EndPoint);
+
+            serializedTransportMessage.Id.ShouldEqual(transportMessage.Id);
+            serializedTransportMessage.MessageTypeId.ShouldEqual(transportMessage.MessageTypeId);
+            serializedTransportMessage.Content.ShouldEqual(transportMessage.Content);
+            serializedTransportMessage.Originator.ShouldEqual(transportMessage.Originator);
+            serializedTransportMessage.Environment.ShouldEqual(transportMessage.Environment);
+            serializedTransportMessage.WasPersisted.ShouldEqual(transportMessage.WasPersisted);
+            serializedTransportMessage.PersistentPeerIds.ShouldBeEquivalentTo(persistMessageCommand.Targets);
+        }
+
+        [Test]
+        public void should_deserialize_persist_message_command()
+        {
+            var transportMessage = new FakeEvent(42).ToTransportMessage(_self);
+            transportMessage.PersistentPeerIds = new List<PeerId> { new PeerId("Abc.Testing.A"), new PeerId("Abc.Testing.B") };
+
+            var message = _messageSerializer.ToMessage(transportMessage).ShouldBe<PersistMessageCommand>();
+
+            var deserializedTransportMessage = message.TransportMessage;
+            deserializedTransportMessage.Id.ShouldEqual(transportMessage.Id);
+            deserializedTransportMessage.MessageTypeId.ShouldEqual(transportMessage.MessageTypeId);
+            deserializedTransportMessage.Content.ShouldEqual(transportMessage.Content);
+            deserializedTransportMessage.Originator.ShouldEqual(transportMessage.Originator);
+            deserializedTransportMessage.Environment.ShouldEqual(transportMessage.Environment);
+            deserializedTransportMessage.WasPersisted.ShouldEqual(transportMessage.WasPersisted);
+
+            message.Targets.ShouldBeEquivalentTo(transportMessage.PersistentPeerIds);
+        }
+    }
+}

--- a/src/Abc.Zebus.Tests/SerializationTests.cs
+++ b/src/Abc.Zebus.Tests/SerializationTests.cs
@@ -20,7 +20,7 @@ namespace Abc.Zebus.Tests
             {
                 MessageId.NextId(),
                 new MessageTypeId("X"),
-                new TransportMessage(new MessageTypeId("lol"), new MemoryStream(new byte[] { 1, 2, 3 }), new PeerId("peer"), "endpoint", MessageId.NextId()),
+                new TransportMessage(new MessageTypeId("lol"), new MemoryStream(new byte[] { 1, 2, 3 }), new PeerId("peer"), "endpoint"),
                 new BindingKey("Abc", "123"),
                 new Peer(new PeerId("Abc.Testing.0"), "tcp://abctest:123", true, true),
             };

--- a/src/Abc.Zebus.Tests/TestDataBuilder.cs
+++ b/src/Abc.Zebus.Tests/TestDataBuilder.cs
@@ -34,7 +34,7 @@ namespace Abc.Zebus.Tests
 
         public static TransportMessage CreateTransportMessage<TMessage>(Stream content)
         {
-            return new TransportMessage(new MessageTypeId(typeof(TMessage)), content, new PeerId("Abc.Testing.0"), "tcp://testing:1234", MessageId.NextId())
+            return new TransportMessage(new MessageTypeId(typeof(TMessage)), content, new PeerId("Abc.Testing.0"), "tcp://testing:1234")
             {
                 Environment = "Test",
                 WasPersisted = true,

--- a/src/Abc.Zebus.Tests/Transport/BackwardCompatibilityTests.cs
+++ b/src/Abc.Zebus.Tests/Transport/BackwardCompatibilityTests.cs
@@ -16,7 +16,7 @@ namespace Abc.Zebus.Tests.Transport
             var content = new MemoryStream(new byte[] { 1, 2, 3 });
             var originatorInfo = new OriginatorInfo(new PeerId("peer"), "endpoint", "MACHINEXXX", "username");
             var messageId = new MessageId(Guid.Parse("ce0ac850-a9c5-e511-932e-d8e94a2d2418"));
-            var expectedMessage = new TransportMessage(new MessageTypeId("lol"), content, originatorInfo, messageId);
+            var expectedMessage = new TransportMessage(new MessageTypeId("lol"), content, originatorInfo) { Id = messageId };
 
             var stream = GetTransportMessageStream_1_4_1();
             var codedInputStream = new CodedInputStream(stream.GetBuffer(), 0, (int)stream.Length);
@@ -31,7 +31,7 @@ namespace Abc.Zebus.Tests.Transport
             var content = new MemoryStream(new byte[] { 1, 2, 3 });
             var originatorInfo = new OriginatorInfo(new PeerId("peer"), "endpoint", "MACHINEXXX", "username");
             var messageId = new MessageId(Guid.Parse("ce0ac850-a9c5-e511-932e-d8e94a2d2418"));
-            var expectedMessage = new TransportMessage(new MessageTypeId("lol"), content, originatorInfo, messageId) { WasPersisted = false };
+            var expectedMessage = new TransportMessage(new MessageTypeId("lol"), content, originatorInfo) { Id = messageId, WasPersisted = false };
 
             var stream = GetTransportMessageStream_1_4_1();
             var codedInputStream = new CodedInputStream(stream.GetBuffer(), 0, (int)stream.Length);

--- a/src/Abc.Zebus.Tests/Transport/TransportMessageReaderTests.cs
+++ b/src/Abc.Zebus.Tests/Transport/TransportMessageReaderTests.cs
@@ -44,7 +44,7 @@ namespace Abc.Zebus.Tests.Transport
 
             var outputStream = new CodedOutputStream();
             outputStream.WriteTransportMessage(transportMessage);
-            outputStream.WritePersistentPeerIds(transportMessage);
+            outputStream.WritePersistentPeerIds(transportMessage, transportMessage.PersistentPeerIds);
 
             var inputStream = new CodedInputStream(outputStream.Buffer, 0, outputStream.Position);
             var deserialized = inputStream.ReadTransportMessage();

--- a/src/Abc.Zebus.Tests/Transport/TransportMessageReaderTests.cs
+++ b/src/Abc.Zebus.Tests/Transport/TransportMessageReaderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using Abc.Zebus.Serialization.Protobuf;
 using Abc.Zebus.Testing.Extensions;
 using Abc.Zebus.Testing.Measurements;
@@ -29,6 +30,28 @@ namespace Abc.Zebus.Tests.Transport
             deserialized.Originator.ShouldEqualDeeply(transportMessage.Originator);
             deserialized.Environment.ShouldEqual(transportMessage.Environment);
             deserialized.WasPersisted.ShouldEqual(transportMessage.WasPersisted);
+        }
+
+        [Test]
+        public void should_read_message_with_persistent_peer_ids()
+        {
+            var transportMessage = TestDataBuilder.CreateTransportMessage<FakeCommand>();
+            transportMessage.PersistentPeerIds = new List<PeerId>
+            {
+                new PeerId("Abc.Testing.A"),
+                new PeerId("Abc.Testing.B"),
+            };
+
+            var outputStream = new CodedOutputStream();
+            outputStream.WriteTransportMessage(transportMessage);
+            outputStream.WritePersistentPeerIds(transportMessage);
+
+            var inputStream = new CodedInputStream(outputStream.Buffer, 0, outputStream.Position);
+            var deserialized = inputStream.ReadTransportMessage();
+
+            deserialized.Id.ShouldEqual(transportMessage.Id);
+            deserialized.MessageTypeId.ShouldEqual(transportMessage.MessageTypeId);
+            deserialized.PersistentPeerIds.ShouldEqual(transportMessage.PersistentPeerIds);
         }
 
         [Test]

--- a/src/Abc.Zebus.Tests/Transport/TransportMessageWriterTests.cs
+++ b/src/Abc.Zebus.Tests/Transport/TransportMessageWriterTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using Abc.Zebus.Serialization.Protobuf;
 using Abc.Zebus.Testing.Extensions;
@@ -50,6 +51,26 @@ namespace Abc.Zebus.Tests.Transport
             deserialized.Originator.InitiatorUserName.ShouldEqual(transportMessage.Originator.InitiatorUserName);
             deserialized.Environment.ShouldEqual(transportMessage.Environment);
             deserialized.WasPersisted.ShouldEqual(true);
+        }
+
+        [Test]
+        public void should_serialize_transport_message_with_persistent_peer_ids_and_read_from_protobuf()
+        {
+            var transportMessage = TestDataBuilder.CreateTransportMessage<FakeCommand>();
+            transportMessage.PersistentPeerIds = new List<PeerId>
+            {
+                new PeerId("Abc.Testing.A"),
+                new PeerId("Abc.Testing.B"),
+            };
+
+            var stream = new CodedOutputStream();
+            stream.WriteTransportMessage(transportMessage);
+            stream.WritePersistentPeerIds(transportMessage);
+
+            var deserialized = Serializer.Deserialize<TransportMessage>(new MemoryStream(stream.Buffer, 0, stream.Position));
+            deserialized.Id.ShouldEqual(transportMessage.Id);
+            deserialized.MessageTypeId.ShouldEqual(transportMessage.MessageTypeId);
+            deserialized.PersistentPeerIds.ShouldBeEquivalentTo(transportMessage.PersistentPeerIds);
         }
 
         [Test]

--- a/src/Abc.Zebus.Tests/Transport/TransportMessageWriterTests.cs
+++ b/src/Abc.Zebus.Tests/Transport/TransportMessageWriterTests.cs
@@ -92,6 +92,25 @@ namespace Abc.Zebus.Tests.Transport
             deserializedTransportMessage1.WasPersisted.ShouldEqual(true);
         }
 
+        [TestCase(null, true)]
+        [TestCase(null, false)]
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        public void should_serialize_transport_message_and_set_WasPersisted(bool? previousWasPersistedValue, bool newWasPersistedValue)
+        {
+            var transportMessage = TestDataBuilder.CreateTransportMessage<FakeCommand>();
+            transportMessage.WasPersisted = previousWasPersistedValue;
+
+            var stream = new CodedOutputStream();
+            stream.WriteTransportMessage(transportMessage);
+            stream.SetWasPersisted(newWasPersistedValue);
+
+            var deserializedTransportMessage1 = Serializer.Deserialize<TransportMessage>(new MemoryStream(stream.Buffer, 0, stream.Position));
+            deserializedTransportMessage1.Id.ShouldEqual(transportMessage.Id);
+            deserializedTransportMessage1.Environment.ShouldEqual(transportMessage.Environment);
+            deserializedTransportMessage1.WasPersisted.ShouldEqual(newWasPersistedValue);
+        }
+
         [Test]
         public void should_serialize_transport_message_twice()
         {
@@ -103,7 +122,7 @@ namespace Abc.Zebus.Tests.Transport
             var deserialized1 = Serializer.Deserialize<TransportMessage_1_5_0>(new MemoryStream(stream.Buffer, 0, stream.Position));
             deserialized1.WasPersisted.ShouldEqual(true);
 
-            stream.Position = 0;
+            stream.Reset();
             transportMessage.WasPersisted = false;
             stream.WriteTransportMessage(transportMessage);
 
@@ -124,7 +143,7 @@ namespace Abc.Zebus.Tests.Transport
             {
                 for (var i = 0; i < count; i++)
                 {
-                    stream.Position = 0;
+                    stream.Reset();
                     stream.WriteTransportMessage(transportMessage);
                 }
             }

--- a/src/Abc.Zebus.Tests/Transport/TransportMessageWriterTests.cs
+++ b/src/Abc.Zebus.Tests/Transport/TransportMessageWriterTests.cs
@@ -65,7 +65,7 @@ namespace Abc.Zebus.Tests.Transport
 
             var stream = new CodedOutputStream();
             stream.WriteTransportMessage(transportMessage);
-            stream.WritePersistentPeerIds(transportMessage);
+            stream.WritePersistentPeerIds(transportMessage, transportMessage.PersistentPeerIds);
 
             var deserialized = Serializer.Deserialize<TransportMessage>(new MemoryStream(stream.Buffer, 0, stream.Position));
             deserialized.Id.ShouldEqual(transportMessage.Id);

--- a/src/Abc.Zebus.Tests/Transport/ZmqTransportTests.cs
+++ b/src/Abc.Zebus.Tests/Transport/ZmqTransportTests.cs
@@ -368,14 +368,14 @@ namespace Abc.Zebus.Tests.Transport
             var messageBytes = new byte[5000];
             new Random().NextBytes(messageBytes);
 
-            var bigMessage = new TransportMessage(new MessageTypeId(typeof(FakeCommand)), TestDataBuilder.CreateStream(messageBytes), new PeerId("X"), senderTransport.InboundEndPoint, MessageId.NextId());
+            var bigMessage = new TransportMessage(new MessageTypeId(typeof(FakeCommand)), TestDataBuilder.CreateStream(messageBytes), new PeerId("X"), senderTransport.InboundEndPoint);
             senderTransport.Send(bigMessage, new[] { receiver });
 
             Wait.Until(() => receviedMessages.Count == 1, 150.Milliseconds());
 
             receviedMessages[0].ShouldHaveSamePropertiesAs(bigMessage);
 
-            var smallMessage = new TransportMessage(new MessageTypeId(typeof(FakeCommand)), TestDataBuilder.CreateStream(new byte[1]), new PeerId("X"), senderTransport.InboundEndPoint, MessageId.NextId());
+            var smallMessage = new TransportMessage(new MessageTypeId(typeof(FakeCommand)), TestDataBuilder.CreateStream(new byte[1]), new PeerId("X"), senderTransport.InboundEndPoint);
             senderTransport.Send(smallMessage, new[] { receiver });
 
             Wait.Until(() => receviedMessages.Count == 2, 150.Milliseconds());

--- a/src/Abc.Zebus.Tests/Util/SystemDateTimeTests.cs
+++ b/src/Abc.Zebus.Tests/Util/SystemDateTimeTests.cs
@@ -12,15 +12,13 @@ namespace Abc.Zebus.Tests.Util
         [Test]
         public void should_be_equal_to_datetime_when_not_set_or_paused()
         {
-            GC.KeepAlive(SystemDateTime.UtcNow);
-
             var dateTimeUtcNow = DateTime.UtcNow;
             var sysDateTimeUtcNow = SystemDateTime.UtcNow;
-            sysDateTimeUtcNow.Subtract(dateTimeUtcNow).ShouldBeLessOrEqualThan(2.Milliseconds());
+            sysDateTimeUtcNow.Subtract(dateTimeUtcNow).ShouldBeLessOrEqualThan(5.Milliseconds());
 
             var dateTimeNow = DateTime.Now;
             var sysDateTimeNow = SystemDateTime.Now;
-            sysDateTimeNow.Subtract(dateTimeNow).ShouldBeLessOrEqualThan(2.Milliseconds());
+            sysDateTimeNow.Subtract(dateTimeNow).ShouldBeLessOrEqualThan(5.Milliseconds());
         }
 
         [Test]

--- a/src/Abc.Zebus.Tests/Util/SystemDateTimeTests.cs
+++ b/src/Abc.Zebus.Tests/Util/SystemDateTimeTests.cs
@@ -12,6 +12,8 @@ namespace Abc.Zebus.Tests.Util
         [Test]
         public void should_be_equal_to_datetime_when_not_set_or_paused()
         {
+            GC.KeepAlive(SystemDateTime.UtcNow);
+
             var dateTimeUtcNow = DateTime.UtcNow;
             var sysDateTimeUtcNow = SystemDateTime.UtcNow;
             sysDateTimeUtcNow.Subtract(dateTimeUtcNow).ShouldBeLessOrEqualThan(2.Milliseconds());

--- a/src/Abc.Zebus/Abc.Zebus.csproj
+++ b/src/Abc.Zebus/Abc.Zebus.csproj
@@ -23,6 +23,7 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="clrzmq">

--- a/src/Abc.Zebus/Core/Bus.cs
+++ b/src/Abc.Zebus/Core/Bus.cs
@@ -470,7 +470,7 @@ namespace Abc.Zebus.Core
             if (!_messageIdToTaskCompletionSources.TryRemove(message.SourceCommandId, out taskCompletionSource))
                 return;
 
-            var response = message.PayloadTypeId != null ? ToMessage(message.PayloadTypeId, new MemoryStream(message.Payload), transportMessage) : null;
+            var response = message.PayloadTypeId != default(MessageTypeId) ? ToMessage(message.PayloadTypeId, new MemoryStream(message.Payload), transportMessage) : null;
             var commandResult = new CommandResult(message.ErrorCode, message.ResponseMessage, response);
 
             Task.Run(() => taskCompletionSource.SetResult(commandResult));

--- a/src/Abc.Zebus/Directory/MessageBinding.cs
+++ b/src/Abc.Zebus/Directory/MessageBinding.cs
@@ -40,7 +40,7 @@ namespace Abc.Zebus.Directory
         {
             unchecked
             {
-                return ((MessageTypeId?.GetHashCode() ?? 0) * 397) ^ RoutingKey.GetHashCode();
+                return (MessageTypeId.GetHashCode() * 397) ^ RoutingKey.GetHashCode();
             }
         }
     }

--- a/src/Abc.Zebus/Directory/SubscriptionsForType.cs
+++ b/src/Abc.Zebus/Directory/SubscriptionsForType.cs
@@ -42,7 +42,7 @@ namespace Abc.Zebus.Directory
             => BindingKeys?.Select(bindingKey => new Subscription(MessageTypeId, bindingKey)).ToArray() ?? new Subscription[0];
 
         public bool Equals(SubscriptionsForType other)
-            => Equals(MessageTypeId, other.MessageTypeId) && BindingKeys.SequenceEqual(other.BindingKeys);
+            => other != null && Equals(MessageTypeId, other.MessageTypeId) && BindingKeys.SequenceEqual(other.BindingKeys);
 
         public override bool Equals(object obj)
         {
@@ -59,7 +59,7 @@ namespace Abc.Zebus.Directory
         {
             unchecked
             {
-                return ((MessageTypeId?.GetHashCode() ?? 0) * 397) ^ (BindingKeys?.GetHashCode() ?? 0);
+                return (MessageTypeId.GetHashCode() * 397) ^ (BindingKeys?.GetHashCode() ?? 0);
             }
         }
     }

--- a/src/Abc.Zebus/MessageTypeId.cs
+++ b/src/Abc.Zebus/MessageTypeId.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using ProtoBuf;
 
 namespace Abc.Zebus
 {
     [ProtoContract]
-    public class MessageTypeId : IEquatable<MessageTypeId>
+    public struct MessageTypeId : IEquatable<MessageTypeId>
     {
         public static readonly MessageTypeId EndOfStream = new MessageTypeId("Abc.Zebus.Transport.EndOfStream");
         public static readonly MessageTypeId EndOfStreamAck = new MessageTypeId("Abc.Zebus.Transport.EndOfStreamAck");
@@ -23,10 +24,6 @@ namespace Abc.Zebus
             _descriptor = MessageUtil.GetMessageTypeDescriptor(fullName);
         }
 
-        private MessageTypeId()
-        {
-        }
-
         [ProtoMember(1, IsRequired = true)]
         public string FullName
         {
@@ -35,10 +32,8 @@ namespace Abc.Zebus
         }
 
         public Type GetMessageType() => _descriptor?.MessageType;
-
-        public bool IsInfrastructure() => _descriptor != null ? _descriptor.IsInfrastructure : false;
-
-        public bool IsPersistent() => _descriptor != null ? _descriptor.IsPersistent : true;
+        public bool IsInfrastructure() => _descriptor?.IsInfrastructure ?? false;
+        public bool IsPersistent() => _descriptor?.IsPersistent ?? true;
 
         public override string ToString()
         {
@@ -46,23 +41,13 @@ namespace Abc.Zebus
             return lastDotIndex != -1 ? FullName.Substring(lastDotIndex + 1) : FullName;
         }
 
-        public bool Equals(MessageTypeId other)
-        {
-            return other != null && _descriptor == other._descriptor;
-        }
+        public bool Equals(MessageTypeId other) => _descriptor == other._descriptor;
+        public override bool Equals(object obj) => obj is MessageTypeId && Equals((MessageTypeId)obj);
 
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as MessageTypeId);
-        }
-
-        public override int GetHashCode()
-        {
-            return _descriptor != null ? _descriptor.GetHashCode() : 0;
-        }
+        [SuppressMessage("ReSharper", "NonReadonlyMemberInGetHashCode")]
+        public override int GetHashCode() => _descriptor?.GetHashCode() ?? 0;
 
         public static bool operator ==(MessageTypeId left, MessageTypeId right) => Equals(left, right);
-
         public static bool operator !=(MessageTypeId left, MessageTypeId right) => !Equals(left, right);
     }
 }

--- a/src/Abc.Zebus/PeerId.cs
+++ b/src/Abc.Zebus/PeerId.cs
@@ -25,7 +25,7 @@ namespace Abc.Zebus
         public static bool operator ==(PeerId left, PeerId right) => left.Equals(right);
         public static bool operator !=(PeerId left, PeerId right) => !left.Equals(right);
 
-        public override string ToString() => _value;
+        public override string ToString() => _value ?? string.Empty;
 
         public bool IsInstanceOf(string serviceName)
             => StringComparer.OrdinalIgnoreCase.Equals(_value.Qualifier(), serviceName);

--- a/src/Abc.Zebus/Persistence/PersistMessageCommand.cs
+++ b/src/Abc.Zebus/Persistence/PersistMessageCommand.cs
@@ -1,4 +1,6 @@
-﻿using Abc.Zebus.Transport;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Abc.Zebus.Transport;
 using ProtoBuf;
 
 namespace Abc.Zebus.Persistence
@@ -10,9 +12,13 @@ namespace Abc.Zebus.Persistence
         public readonly TransportMessage TransportMessage;
 
         [ProtoMember(2, IsRequired = true)]
-        public readonly PeerId[] Targets;
+        public readonly List<PeerId> Targets;
 
-        public PersistMessageCommand(TransportMessage transportMessage, PeerId[] targets)
+        public PersistMessageCommand(TransportMessage transportMessage, params PeerId[] targets) : this(transportMessage, targets.ToList())
+        {
+        }
+
+        public PersistMessageCommand(TransportMessage transportMessage, List<PeerId> targets)
         {
             TransportMessage = transportMessage;
             Targets = targets;

--- a/src/Abc.Zebus/Persistence/PersistentTransport.cs
+++ b/src/Abc.Zebus/Persistence/PersistentTransport.cs
@@ -158,7 +158,7 @@ namespace Abc.Zebus.Persistence
 
         public void Send(TransportMessage message, IEnumerable<Peer> peers, SendContext context)
         {
-            if (context.PersistedPeerIds.Any())
+            if (context.PersistentPeerIds.Count != 0)
                 throw new ArgumentException("Send invoked with non-empty send context", nameof(context));
 
             var isMessagePersistent = _messageSendingStrategy.IsMessagePersistent(message);
@@ -166,10 +166,10 @@ namespace Abc.Zebus.Persistence
 
             _innerTransport.Send(message, targetPeers, context);
             
-            if (context.PersistedPeerIds.Count == 0)
+            if (context.PersistentPeerIds.Count == 0)
                 return;
             
-            var persistMessageCommand = new PersistMessageCommand(message, context.PersistedPeerIds);
+            var persistMessageCommand = new PersistMessageCommand(message, context.PersistentPeerIds);
             EnqueueOrSendToPersistenceService(persistMessageCommand);
         }
 
@@ -182,7 +182,7 @@ namespace Abc.Zebus.Persistence
             {
                 var peer = peerList[index];
                 if (isMessagePersistent && _peerDirectory.IsPersistent(peer.Id))
-                    context.PersistedPeerIds.Add(peer.Id);
+                    context.PersistentPeerIds.Add(peer.Id);
 
                 hasDownPeer |= !peer.IsUp;
             }

--- a/src/Abc.Zebus/Serialization/MessageSerializerExtensions.cs
+++ b/src/Abc.Zebus/Serialization/MessageSerializerExtensions.cs
@@ -16,7 +16,7 @@ namespace Abc.Zebus.Serialization
 
         public static IMessage ToMessage(this IMessageSerializer serializer, TransportMessage transportMessage)
         {
-            if (transportMessage.PersistentPeerIds != null && transportMessage.PersistentPeerIds.Count != 0)
+            if (transportMessage.IsPersistTransportMessage)
                 return ToPersistMessageCommand(transportMessage);
 
             return serializer.Deserialize(transportMessage.MessageTypeId, transportMessage.Content);
@@ -25,7 +25,7 @@ namespace Abc.Zebus.Serialization
         private static TransportMessage ToTransportMessage(PersistMessageCommand persistMessageCommand)
         {
             var targetMessage = persistMessageCommand.TransportMessage;
-            return targetMessage.WithPersistentPeerIds(persistMessageCommand.Targets);
+            return targetMessage.ToPersistTransportMessage(persistMessageCommand.Targets);
         }
 
         private static IMessage ToPersistMessageCommand(TransportMessage transportMessage)

--- a/src/Abc.Zebus/Serialization/MessageSerializerExtensions.cs
+++ b/src/Abc.Zebus/Serialization/MessageSerializerExtensions.cs
@@ -23,23 +23,9 @@ namespace Abc.Zebus.Serialization
         }
 
         private static TransportMessage ToTransportMessage(PersistMessageCommand persistMessageCommand)
-        {
-            var targetMessage = persistMessageCommand.TransportMessage;
-            return targetMessage.ToPersistTransportMessage(persistMessageCommand.Targets);
-        }
+            => persistMessageCommand.TransportMessage.ToPersistTransportMessage(persistMessageCommand.Targets);
 
         private static IMessage ToPersistMessageCommand(TransportMessage transportMessage)
-        {
-            var targetTransportMessage = new TransportMessage
-            {
-                Id = transportMessage.Id,
-                MessageTypeId = transportMessage.MessageTypeId,
-                Content = transportMessage.Content,
-                Originator = transportMessage.Originator,
-                Environment = transportMessage.Environment,
-                WasPersisted = transportMessage.WasPersisted,
-            };
-            return new PersistMessageCommand(targetTransportMessage, transportMessage.PersistentPeerIds);
-        }
+            => new PersistMessageCommand(transportMessage.UnpackPersistTransportMessage(), transportMessage.PersistentPeerIds);
     }
 }

--- a/src/Abc.Zebus/Serialization/MessageSerializerExtensions.cs
+++ b/src/Abc.Zebus/Serialization/MessageSerializerExtensions.cs
@@ -1,17 +1,45 @@
-﻿using Abc.Zebus.Transport;
+﻿using Abc.Zebus.Persistence;
+using Abc.Zebus.Transport;
 
 namespace Abc.Zebus.Serialization
 {
     public static class MessageSerializerExtensions
     {
-        public static TransportMessage ToTransportMessage(this IMessageSerializer serializer, IMessage message, MessageId messageId, PeerId peerId, string peerEndPoint)
+        public static TransportMessage ToTransportMessage(this IMessageSerializer serializer, IMessage message, PeerId peerId, string peerEndPoint)
         {
-            return new TransportMessage(message.TypeId(), serializer.Serialize(message), peerId, peerEndPoint, messageId);
+            var persistMessageCommand = message as PersistMessageCommand;
+            if (persistMessageCommand != null)
+                return ToTransportMessage(persistMessageCommand);
+
+            return new TransportMessage(message.TypeId(), serializer.Serialize(message), peerId, peerEndPoint);
         }
 
         public static IMessage ToMessage(this IMessageSerializer serializer, TransportMessage transportMessage)
         {
+            if (transportMessage.PersistentPeerIds != null && transportMessage.PersistentPeerIds.Count != 0)
+                return ToPersistMessageCommand(transportMessage);
+
             return serializer.Deserialize(transportMessage.MessageTypeId, transportMessage.Content);
+        }
+
+        private static TransportMessage ToTransportMessage(PersistMessageCommand persistMessageCommand)
+        {
+            var targetMessage = persistMessageCommand.TransportMessage;
+            return targetMessage.WithPersistentPeerIds(persistMessageCommand.Targets);
+        }
+
+        private static IMessage ToPersistMessageCommand(TransportMessage transportMessage)
+        {
+            var targetTransportMessage = new TransportMessage
+            {
+                Id = transportMessage.Id,
+                MessageTypeId = transportMessage.MessageTypeId,
+                Content = transportMessage.Content,
+                Originator = transportMessage.Originator,
+                Environment = transportMessage.Environment,
+                WasPersisted = transportMessage.WasPersisted,
+            };
+            return new PersistMessageCommand(targetTransportMessage, transportMessage.PersistentPeerIds);
         }
     }
 }

--- a/src/Abc.Zebus/Serialization/Protobuf/CodedOutputStream.cs
+++ b/src/Abc.Zebus/Serialization/Protobuf/CodedOutputStream.cs
@@ -198,30 +198,8 @@ namespace Abc.Zebus.Serialization.Protobuf
         /// <param name="value">The value to write</param>
         public void WriteString(string value)
         {
-            // Optimise the case where we have enough space to write
-            // the string directly to the buffer, which should be common.
             int length = Utf8Encoding.GetByteCount(value);
-            WriteLength(length);
-            if (buffer.Length - position >= length)
-            {
-                if (length == value.Length) // Must be all ASCII...
-                {
-                    for (int i = 0; i < length; i++)
-                    {
-                        buffer[position + i] = (byte)value[i];
-                    }
-                }
-                else
-                {
-                    Utf8Encoding.GetBytes(value, 0, value.Length, buffer, position);
-                }
-                position += length;
-            }
-            else
-            {
-                byte[] bytes = Utf8Encoding.GetBytes(value);
-                WriteRawBytes(bytes);
-            }
+            WriteString(value, length);
         }
 
         /// <summary>
@@ -526,13 +504,21 @@ namespace Abc.Zebus.Serialization.Protobuf
 
         public void WriteGuid(Guid value)
         {
-            WriteLength(GuidSize);
+            EnsureCapacity(GuidSize + 1);
+
+            buffer[position++] = GuidSize; // length
 
             var blob = value.ToByteArray();
-            WriteRawTag(9);
-            WriteRawBytes(blob, 0, 8);
-            WriteRawTag(17);
-            WriteRawBytes(blob, 8, 8);
+            buffer[position++] = 1 << 3 | 1; // tag
+            for (var i = 0; i < 8; i++)
+            {
+                buffer[position++] = blob[i];
+            }
+            buffer[position++] = 2 << 3 | 1; // tag
+            for (var i = 8; i < 16; i++)
+            {
+                buffer[position++] = blob[i];
+            }
         }
 
         /// <summary>

--- a/src/Abc.Zebus/Serialization/Protobuf/CodedOutputStream.cs
+++ b/src/Abc.Zebus/Serialization/Protobuf/CodedOutputStream.cs
@@ -66,6 +66,7 @@ namespace Abc.Zebus.Serialization.Protobuf
 
         private byte[] buffer;
         private int position;
+        private int? savedPosition;
 
         #region Construction
         public CodedOutputStream() : this(new byte[DefaultBufferSize])
@@ -90,7 +91,26 @@ namespace Abc.Zebus.Serialization.Protobuf
         public int Position
         {
             get { return position; }
-            set { position = value; }
+        }
+
+        public void Reset()
+        {
+            position = 0;
+            savedPosition = null;
+        }
+
+        public void SavePosition()
+        {
+            savedPosition = position;
+        }
+
+        public bool TryWriteBoolAtSavedPosition(bool value)
+        {
+            if (savedPosition == null)
+                return false;
+
+            buffer[savedPosition.Value] = value ? (byte)1 : (byte)0;
+            return true;
         }
 
         #region Writing of values (not including tags)

--- a/src/Abc.Zebus/Subscription.cs
+++ b/src/Abc.Zebus/Subscription.cs
@@ -98,7 +98,7 @@ namespace Abc.Zebus
             {
                 // ReSharper disable NonReadonlyMemberInGetHashCode
                 if (_computedHashCode == 0)
-                    _computedHashCode = ((MessageTypeId?.GetHashCode() ?? 0) * 397) ^ BindingKey.GetHashCode();
+                    _computedHashCode = (MessageTypeId.GetHashCode() * 397) ^ BindingKey.GetHashCode();
 
                 return _computedHashCode;
                 // ReSharper restore NonReadonlyMemberInGetHashCode
@@ -202,10 +202,10 @@ namespace Abc.Zebus
 
         private static void AddFieldValueFromUnaryExpression<T>(Dictionary<string, string> fieldValues, UnaryExpression unaryExpression)
         {
-            if(unaryExpression.Type != typeof(bool))
+            if (unaryExpression.Type != typeof(bool))
                 throw CreateArgumentException(unaryExpression);
 
-            if(unaryExpression.NodeType != ExpressionType.Not)
+            if (unaryExpression.NodeType != ExpressionType.Not)
                 throw CreateArgumentException(unaryExpression);
 
             var currentFieldValue = false;
@@ -254,11 +254,11 @@ namespace Abc.Zebus
 
             var memberName = memberExpression.Member.Name;
             var memberValue = Expression.Lambda(memberValueExpression).Compile().DynamicInvoke();
+            if (memberValue == null)
+                return;
 
             var valueAsText = memberExpression.Type.IsEnum ? Enum.GetName(memberExpression.Type, memberValue) : memberValue.ToString();
-
-            if (memberValue != null)
-                fieldValues.Add(memberName, valueAsText);
+            fieldValues.Add(memberName, valueAsText);
         }
 
         private static bool TryGetMessageMemberExpression<TMessage>(Expression expression, out MemberExpression memberExpression)

--- a/src/Abc.Zebus/Transport/SendContext.cs
+++ b/src/Abc.Zebus/Transport/SendContext.cs
@@ -7,7 +7,7 @@ namespace Abc.Zebus.Transport
         public List<PeerId> PersistentPeerIds { get; } = new List<PeerId>();
         public Peer PersistencePeer { get; set; }
 
-        public bool IsPersistent(PeerId peerId)
+        public bool WasPersisted(PeerId peerId)
         {
             for (var index = 0; index < PersistentPeerIds.Count; index++)
             {

--- a/src/Abc.Zebus/Transport/SendContext.cs
+++ b/src/Abc.Zebus/Transport/SendContext.cs
@@ -4,6 +4,17 @@ namespace Abc.Zebus.Transport
 {
     public class SendContext
     {
-        public readonly List<PeerId> PersistedPeerIds = new List<PeerId>();
+        public List<PeerId> PersistentPeerIds { get; } = new List<PeerId>();
+        public Peer PersistencePeer { get; set; }
+
+        public bool IsPersistent(PeerId peerId)
+        {
+            for (var index = 0; index < PersistentPeerIds.Count; index++)
+            {
+                if (PersistentPeerIds[index] == peerId)
+                    return true;
+            }
+            return false;
+        }
     }
 }

--- a/src/Abc.Zebus/Transport/TransportMessage.cs
+++ b/src/Abc.Zebus/Transport/TransportMessage.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using Abc.Zebus.Util;
 using Abc.Zebus.Util.Annotations;
 using ProtoBuf;
@@ -32,6 +33,9 @@ namespace Abc.Zebus.Transport
 
         [ProtoMember(6, IsRequired = false)]
         public bool? WasPersisted { get; internal set; }
+
+        [ProtoMember(7, IsRequired = false)]
+        internal List<PeerId> PersistentPeerIds { get; set; }
 
         public TransportMessage(MessageTypeId messageTypeId, Stream content, Peer sender)
             : this(messageTypeId, content, sender.Id, sender.EndPoint, MessageId.NextId())

--- a/src/Abc.Zebus/Transport/TransportMessage.cs
+++ b/src/Abc.Zebus/Transport/TransportMessage.cs
@@ -36,7 +36,10 @@ namespace Abc.Zebus.Transport
         public bool? WasPersisted { get; internal set; }
 
         [ProtoMember(7, IsRequired = false)]
-        internal List<PeerId> PersistentPeerIds { get; set; }
+        public List<PeerId> PersistentPeerIds { get; set; }
+
+        [JsonIgnore]
+        public bool IsPersistTransportMessage => PersistentPeerIds != null && PersistentPeerIds.Count != 0;
 
         public TransportMessage(MessageTypeId messageTypeId, Stream content, Peer sender)
             : this(messageTypeId, content, sender.Id, sender.EndPoint)
@@ -80,7 +83,7 @@ namespace Abc.Zebus.Transport
             return buffer;
         }
 
-        internal TransportMessage WithPersistentPeerIds(List<PeerId> peerIds)
+        internal TransportMessage ToPersistTransportMessage(List<PeerId> peerIds)
         {
             return new TransportMessage
             {

--- a/src/Abc.Zebus/Transport/TransportMessage.cs
+++ b/src/Abc.Zebus/Transport/TransportMessage.cs
@@ -47,7 +47,7 @@ namespace Abc.Zebus.Transport
         }
 
         public TransportMessage(MessageTypeId messageTypeId, Stream content, PeerId senderId, string senderEndPoint)
-            : this (messageTypeId, content, CreateOriginator(senderId, senderEndPoint))
+            : this(messageTypeId, content, CreateOriginator(senderId, senderEndPoint))
         {
         }
 
@@ -83,18 +83,18 @@ namespace Abc.Zebus.Transport
             return buffer;
         }
 
-        internal TransportMessage ToPersistTransportMessage(List<PeerId> peerIds)
+        internal TransportMessage ToPersistTransportMessage(List<PeerId> peerIds) => CloneWithPeerIds(peerIds);
+        internal TransportMessage UnpackPersistTransportMessage() => CloneWithPeerIds(null);
+
+        private TransportMessage CloneWithPeerIds(List<PeerId> peerIds) => new TransportMessage
         {
-            return new TransportMessage
-            {
-                Id = Id,
-                MessageTypeId = MessageTypeId,
-                Content = Content,
-                Originator = Originator,
-                Environment = Environment,
-                WasPersisted = WasPersisted,
-                PersistentPeerIds = peerIds,
-            };
-        }
+            Id = Id,
+            MessageTypeId = MessageTypeId,
+            Content = Content,
+            Originator = Originator,
+            Environment = Environment,
+            WasPersisted = WasPersisted,
+            PersistentPeerIds = peerIds,
+        };
     }
 }

--- a/src/Abc.Zebus/Transport/TransportMessageReader.cs
+++ b/src/Abc.Zebus/Transport/TransportMessageReader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Abc.Zebus.Serialization.Protobuf;
 using ProtoBuf;
@@ -34,6 +35,9 @@ namespace Abc.Zebus.Transport
                         break;
                     case 6:
                         transportMessage.WasPersisted = input.ReadBool();
+                        break;
+                    case 7:
+                        transportMessage.PersistentPeerIds = ReadPeerIds(input, transportMessage.PersistentPeerIds);
                         break;
                     default:
                         SkipUnknown(input, wireType);
@@ -129,6 +133,17 @@ namespace Abc.Zebus.Transport
             }
 
             return value;
+        }
+
+        private static List<PeerId> ReadPeerIds(CodedInputStream input, List<PeerId> peerIds)
+        {
+            if (peerIds == null)
+                peerIds = new List<PeerId>();
+
+            var value = ReadSingleField(input, x => x.ReadString());
+            peerIds.Add(new PeerId(value));
+
+            return peerIds;
         }
 
         private static void SkipUnknown(CodedInputStream input, WireType wireType)

--- a/src/Abc.Zebus/Transport/TransportMessageWriter.cs
+++ b/src/Abc.Zebus/Transport/TransportMessageWriter.cs
@@ -1,10 +1,11 @@
-﻿using Abc.Zebus.Serialization.Protobuf;
+﻿using System.Collections.Generic;
+using Abc.Zebus.Serialization.Protobuf;
 
 namespace Abc.Zebus.Transport
 {
     internal static class TransportMessageWriter
     {
-        internal static void WriteTransportMessage(this CodedOutputStream output, TransportMessage transportMessage, string environment = null)
+        internal static void WriteTransportMessage(this CodedOutputStream output, TransportMessage transportMessage, string environmentOverride = null)
         {
             output.WriteRawTag(1 << 3 | 2);
             Write(output, transportMessage.Id);
@@ -22,12 +23,12 @@ namespace Abc.Zebus.Transport
             output.WriteRawTag(4 << 3 | 2);
             Write(output, transportMessage.Originator);
 
-            var transportMessageEnvironment = transportMessage.Environment ?? environment;
-            if (transportMessageEnvironment != null)
+            var environment = environmentOverride ?? transportMessage.Environment;
+            if (environment != null)
             {
                 output.WriteRawTag(5 << 3 | 2);
-                var environmentLength = GetUtf8ByteCount(transportMessageEnvironment);
-                output.WriteString(transportMessageEnvironment, environmentLength);
+                var environmentLength = GetUtf8ByteCount(environment);
+                output.WriteString(environment, environmentLength);
             }
 
             if (transportMessage.WasPersisted != null)
@@ -42,9 +43,9 @@ namespace Abc.Zebus.Transport
             WriteWasPersisted(output, wasPersisted);
         }
 
-        internal static void WritePersistentPeerIds(this CodedOutputStream output, TransportMessage transportMessage)
+        internal static void WritePersistentPeerIds(this CodedOutputStream output, TransportMessage transportMessage, List<PeerId> persistentPeerIdOverride)
         {
-            var peerIds = transportMessage.PersistentPeerIds;
+            var peerIds = persistentPeerIdOverride ?? transportMessage.PersistentPeerIds;
             if (peerIds == null)
                 return;
 

--- a/src/Abc.Zebus/Transport/TransportMessageWriter.cs
+++ b/src/Abc.Zebus/Transport/TransportMessageWriter.cs
@@ -52,10 +52,10 @@ namespace Abc.Zebus.Transport
             for (var index = 0; index < peerIds.Count; index++)
             {
                 var peerIdString = peerIds[index].ToString();
-                if (peerIdString == null)
+                if (string.IsNullOrEmpty(peerIdString))
                     continue;
 
-                output.WriteTag(7 << 3 | 2);
+                output.WriteRawTag(7 << 3 | 2);
 
                 var peerIdStringLength = GetUtf8ByteCount(peerIdString);
                 var peerIdLength = 1 + CodedOutputStream.ComputeStringSize(peerIdStringLength);
@@ -64,7 +64,6 @@ namespace Abc.Zebus.Transport
                 output.WriteRawTag(1 << 3 | 2);
                 output.WriteString(peerIdString, peerIdStringLength);
             }
-
         }
 
         private static void Write(CodedOutputStream output, MessageId messageId)
@@ -100,7 +99,7 @@ namespace Abc.Zebus.Transport
             var senderIdString = originatorInfo.SenderId.ToString();
             int senderIdLength;
             int senderIdStringLength;
-            if (senderIdString == null)
+            if (string.IsNullOrEmpty(senderIdString))
             {
                 senderIdStringLength = 0;
                 senderIdLength = 0;
@@ -154,7 +153,7 @@ namespace Abc.Zebus.Transport
             output.WriteRawTag(1 << 3 | 2);
             output.WriteLength(senderIdLength);
 
-            if (senderIdString != null)
+            if (!string.IsNullOrEmpty(senderIdString))
             {
                 output.WriteRawTag(1 << 3 | 2);
                 output.WriteString(senderIdString, senderIdStringLength);

--- a/src/Abc.Zebus/Transport/ZmqTransport.cs
+++ b/src/Abc.Zebus/Transport/ZmqTransport.cs
@@ -487,7 +487,7 @@ namespace Abc.Zebus.Transport
 
         private struct OutboundSocketAction
         {
-            private static readonly TransportMessage _disconnectMessage = new TransportMessage(null, null, new PeerId(), null);
+            private static readonly TransportMessage _disconnectMessage = new TransportMessage(default(MessageTypeId), null, new PeerId(), null);
 
             private OutboundSocketAction(TransportMessage message, IEnumerable<Peer> targets, SendContext context)
             {


### PR DESCRIPTION
When a persistent message _msg1_ is sent, it is serialized multiple times:
1. The `Bus` converts _msg1_ to a `TransportMessage` _tmsg1_
2. The `ZmqTransport` converts _tmsg1_ to bytes
3. The `PersistentTransport` generates a `PersistMessageCommand` _msg2_ and converts _msg2_ to a `TransportMessage` _tmsg2_
4. The `ZmqTransport` converts _tmsg2_ to bytes

This PR reduces the serialization steps:
1. The `Bus` converts _msg1_ to a `TransportMessage` _tmsg1_
2. The `ZmqTransport` converts _tmsg1_ to bytes
3. The `ZmqTransport` uses the previously generated bytes and forward them to the persistence

To support this change, a new field is added to `TransportMessage`: `PersistentPeerIds`. This field is only used to forward messages to the persistence service. A TransportMessage with this field is always deserialized to a `PersistMessageCommand`.