### PR TITLE
Inject an error reporter in various zmq outbound socket operations

### DIFF
--- a/src/Abc.Zebus.Tests/Transport/ZmqTransportPerformanceTests.cs
+++ b/src/Abc.Zebus.Tests/Transport/ZmqTransportPerformanceTests.cs
@@ -61,7 +61,7 @@ namespace Abc.Zebus.Tests.Transport
         private ZmqTransport CreateAndStartZmqTransport(string peerId, Action<TransportMessage> onMessageReceived = null)
         {
             var configurationMock = new Mock<IZmqTransportConfiguration>();
-            var transport = new ZmqTransport(configurationMock.Object, new ZmqSocketOptions());
+            var transport = new ZmqTransport(configurationMock.Object, new ZmqSocketOptions(), new DefaultZmqOutboundSocketErrorHandler());
             transport.Configure(new PeerId(peerId), "test");
             transport.SocketOptions.SendTimeout = 5.Seconds();
 

--- a/src/Abc.Zebus.Tests/Transport/ZmqTransportTests.cs
+++ b/src/Abc.Zebus.Tests/Transport/ZmqTransportTests.cs
@@ -51,7 +51,7 @@ namespace Abc.Zebus.Tests.Transport
         {
             var configurationMock = new Mock<IZmqTransportConfiguration>();
             configurationMock.SetupGet(x => x.WaitForEndOfStreamAckTimeout).Returns(100.Milliseconds());
-            var transport = new ZmqTransport(configurationMock.Object, new ZmqSocketOptions());
+            var transport = new ZmqTransport(configurationMock.Object, new ZmqSocketOptions(), new DefaultZmqOutboundSocketErrorHandler());
 
             Assert.That(transport.Stop, Throws.Nothing);
         }
@@ -557,7 +557,7 @@ namespace Abc.Zebus.Tests.Transport
             if (peerId == null)
                 peerId = "Abc.Testing." + _transports.Count;
 
-            var transport = transportFactory == null ? new ZmqTransport(configurationMock.Object, new ZmqSocketOptions()) : transportFactory(configurationMock.Object);
+            var transport = transportFactory == null ? new ZmqTransport(configurationMock.Object, new ZmqSocketOptions(), new DefaultZmqOutboundSocketErrorHandler()) : transportFactory(configurationMock.Object);
             transport.SetLogId(_transports.Count);
 
             transport.SocketOptions.SendTimeout = 10.Milliseconds();
@@ -597,7 +597,7 @@ namespace Abc.Zebus.Tests.Transport
             }
 
 
-            public CapturingIsListeningTimeZmqTransport(IZmqTransportConfiguration configuration, Stopwatch stopwatch) : base(configuration, new ZmqSocketOptions())
+            public CapturingIsListeningTimeZmqTransport(IZmqTransportConfiguration configuration, Stopwatch stopwatch) : base(configuration, new ZmqSocketOptions(), new DefaultZmqOutboundSocketErrorHandler())
             {
                 _stopwatch = stopwatch;
                 IsListeningSwitchTimestamp = TimeSpan.MaxValue;

--- a/src/Abc.Zebus/Abc.Zebus.csproj
+++ b/src/Abc.Zebus/Abc.Zebus.csproj
@@ -221,8 +221,10 @@
     <Compile Include="Timeout\Timeout.cs" />
     <Compile Include="Timeout\TimeoutCommand.cs" />
     <Compile Include="Persistence\IPersistentTransport.cs" />
+    <Compile Include="Transport\DefaultZmqOutboundSocketErrorHandler.cs" />
     <Compile Include="Transport\ITransport.cs" />
     <Compile Include="Peer.cs" />
+    <Compile Include="Transport\IZmqOutboundSocketErrorHandler.cs" />
     <Compile Include="Transport\IZmqTransportConfiguration.cs" />
     <Compile Include="Transport\SendContext.cs" />
     <Compile Include="Transport\TransportMessageReader.cs" />

--- a/src/Abc.Zebus/Initialization/ZebusRegistry.cs
+++ b/src/Abc.Zebus/Initialization/ZebusRegistry.cs
@@ -41,6 +41,8 @@ namespace Abc.Zebus.Initialization
             ForSingletonOf<IStoppingStrategy>().Use<DefaultStoppingStrategy>();
 
             ForSingletonOf<IBindingKeyPredicateBuilder>().Use<BindingKeyPredicateBuilder>();
+
+            ForSingletonOf<IZmqOutboundSocketErrorHandler>().Use<DefaultZmqOutboundSocketErrorHandler>();
         }
     }
 }

--- a/src/Abc.Zebus/Transport/DefaultZmqOutboundSocketErrorHandler.cs
+++ b/src/Abc.Zebus/Transport/DefaultZmqOutboundSocketErrorHandler.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Abc.Zebus.Transport
+{
+    public class DefaultZmqOutboundSocketErrorHandler : IZmqOutboundSocketErrorHandler
+    {
+        public void OnConnectException(PeerId peerId, string endPoint, Exception exception)
+        {
+        }
+
+        public void OnDisconnectException(PeerId peerId, string endPoint, Exception exception)
+        {
+        }
+
+        public void OnSendFailed(PeerId peerId, string endPoint, MessageTypeId messageTypeId, MessageId id)
+        {
+        }
+    }
+}

--- a/src/Abc.Zebus/Transport/IZmqOutboundSocketErrorHandler.cs
+++ b/src/Abc.Zebus/Transport/IZmqOutboundSocketErrorHandler.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Abc.Zebus.Transport
+{
+    public interface IZmqOutboundSocketErrorHandler
+    {
+        void OnConnectException(PeerId peerId, string endPoint, Exception exception);
+        void OnDisconnectException(PeerId peerId, string endPoint, Exception exception);
+        void OnSendFailed(PeerId peerId, string endPoint, MessageTypeId messageTypeId, MessageId id);
+    }
+}

--- a/src/Abc.Zebus/Transport/ZmqOutboundSocket.cs
+++ b/src/Abc.Zebus/Transport/ZmqOutboundSocket.cs
@@ -12,15 +12,17 @@ namespace Abc.Zebus.Transport
         private readonly Stopwatch _closedStateStopwatch = new Stopwatch();
         private readonly ZmqContext _context;
         private readonly ZmqSocketOptions _options;
+        private readonly IZmqOutboundSocketErrorHandler _errorHandler;
         private ZmqSocket _socket;
         private int _failedSendCount;
         private bool _isInClosedState;
         private TimeSpan _closedStateDuration;
 
-        public ZmqOutboundSocket(ZmqContext context, PeerId peerId, string endPoint, ZmqSocketOptions options)
+        public ZmqOutboundSocket(ZmqContext context, PeerId peerId, string endPoint, ZmqSocketOptions options, IZmqOutboundSocketErrorHandler errorHandler)
         {
             _context = context;
             _options = options;
+            _errorHandler = errorHandler;
             PeerId = peerId;
             EndPoint = endPoint;
         }
@@ -56,6 +58,7 @@ namespace Abc.Zebus.Transport
                 IsConnected = false;
 
                 _logger.ErrorFormat("Unable to connect socket, Peer: {0}, EndPoint: {1}, Exception: {2}", PeerId, EndPoint, ex);
+                _errorHandler.OnConnectException(PeerId, EndPoint, ex);
 
                 SwitchToClosedState(_options.ClosedStateDurationAfterConnectFailure);
             }
@@ -83,6 +86,7 @@ namespace Abc.Zebus.Transport
             catch (Exception ex)
             {
                 _logger.ErrorFormat("Unable to disconnect socket, Peer: {0}, Exception: {1}", PeerId, ex);
+                _errorHandler.OnDisconnectException(PeerId, EndPoint, ex);
             }
 
             IsConnected = false;
@@ -100,6 +104,7 @@ namespace Abc.Zebus.Transport
             }
 
             _logger.ErrorFormat("Unable to send message, destination peer: {0}, MessageTypeId: {1}, MessageId: {2}", PeerId, message.MessageTypeId, message.Id);
+            _errorHandler.OnSendFailed(PeerId, EndPoint, message.MessageTypeId, message.Id);
 
             if (_failedSendCount >= _options.SendRetriesBeforeSwitchingToClosedState)
                 SwitchToClosedState(_options.ClosedStateDurationAfterSendFailure);

--- a/src/Abc.Zebus/Transport/ZmqTransport.cs
+++ b/src/Abc.Zebus/Transport/ZmqTransport.cs
@@ -15,6 +15,7 @@ namespace Abc.Zebus.Transport
     public class ZmqTransport : ITransport
     {
         private readonly IZmqTransportConfiguration _configuration;
+        private readonly IZmqOutboundSocketErrorHandler _errorHandler;
         private readonly ZmqEndPoint _configuredInboundEndPoint;
         private ILog _logger = LogManager.GetLogger(typeof(ZmqTransport));
         private ConcurrentDictionary<PeerId, ZmqOutboundSocket> _outboundSockets;
@@ -57,9 +58,10 @@ namespace Abc.Zebus.Transport
             }
         }
 
-        public ZmqTransport(IZmqTransportConfiguration configuration, ZmqSocketOptions socketOptions)
+        public ZmqTransport(IZmqTransportConfiguration configuration, ZmqSocketOptions socketOptions, IZmqOutboundSocketErrorHandler errorHandler)
         {
             _configuration = configuration;
+            _errorHandler = errorHandler;
             _configuredInboundEndPoint = new ZmqEndPoint(configuration.InboundEndPoint);
             SocketOptions = socketOptions;
         }
@@ -414,7 +416,7 @@ namespace Abc.Zebus.Transport
             ZmqOutboundSocket outboundSocket;
             if (!_outboundSockets.TryGetValue(peer.Id, out outboundSocket))
             {
-                outboundSocket = new ZmqOutboundSocket(_context, peer.Id, peer.EndPoint, SocketOptions);
+                outboundSocket = new ZmqOutboundSocket(_context, peer.Id, peer.EndPoint, SocketOptions, _errorHandler);
                 outboundSocket.ConnectFor(transportMessage);
 
                 _outboundSockets.TryAdd(peer.Id, outboundSocket);


### PR DESCRIPTION
Sometimes outbound socket operations might fail because of some network issues. The current implementation of `ZmqOutboundSocket` only logs when these failures happen. These issues are hard to detect since we have to inspect logs to find them.

I've created a `IZmqOutboundSocketErrorHandler` that will be called by `ZmqOutboundSocket` to allow external error handling. 

A default implementation of this error handler is registered in the container, this registration can be overriden when the bus is used in a wider application to do central logging or to publish a custom event (like a `CustomProcessingFailed` ...)