### PR TITLE
Update Nunit from 2.6.4 to 3.10.1

### DIFF
--- a/build/Abc.Zebus.Testing.nuspec
+++ b/build/Abc.Zebus.Testing.nuspec
@@ -17,7 +17,7 @@
       <dependency id="CompareNETObjects" version="3.03.0.0" />
       <dependency id="Moq" version="4.2.1507.0118" />
       <dependency id="Newtonsoft.Json" version="7.0.1" />
-      <dependency id="NUnit" version="2.6.4" />
+      <dependency id="NUnit" version="3.10.1" />
       <dependency id="structuremap" version="3.1.6.186" />
     </dependencies>
   </metadata>

--- a/build/build.cake
+++ b/build/build.cake
@@ -1,5 +1,5 @@
 #l "scripts/utilities.cake"
-#tool nuget:?package=NUnit.Runners.Net4&version=2.6.4
+#tool "nuget:?package=NUnit.ConsoleRunner"
 
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS
@@ -48,8 +48,8 @@ Task("MSBuild").Does(() => MSBuild(paths.solution, settings => settings.SetConfi
 Task("Clean-AssemblyInfo").Does(() => System.IO.File.WriteAllText(paths.assemblyInfo, string.Empty));
 Task("Run-Unit-Tests").Does(() =>
 {
-    NUnit(paths.output.build + "/*.Tests.exe", new NUnitSettings { Framework = "4.6.1", NoResults = true });
-    NUnit(paths.output.build + "/*.Tests.dll", new NUnitSettings { Framework = "4.6.1", NoResults = true });
+    NUnit3(paths.output.build + "/*.Tests.exe", new NUnit3Settings { NoResults = true });
+    NUnit3(paths.output.build + "/*.Tests.dll", new NUnit3Settings { NoResults = true });
 });
 Task("Nuget-Pack").Does(() => 
 {

--- a/src/Abc.Zebus.Testing/Abc.Zebus.Testing.csproj
+++ b/src/Abc.Zebus.Testing/Abc.Zebus.Testing.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="CompareNETObjects" Version="3.03.0.0" />
     <PackageReference Include="Moq" Version="4.2.1507.0118" />
     <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
-    <PackageReference Include="NUnit" Version="2.6.4" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="protobuf-net" Version="2.0.0.668" />
     <PackageReference Include="structuremap" Version="3.1.6.186" />
   </ItemGroup>

--- a/src/Abc.Zebus.Testing/Extensions/NUnitExtensions.cs
+++ b/src/Abc.Zebus.Testing/Extensions/NUnitExtensions.cs
@@ -152,8 +152,9 @@ namespace Abc.Zebus.Testing.Extensions
         {
             foreach (var obj in actual)
             {
-                var empty = Tolerance.Empty;
-                if (NUnitEqualityComparer.Default.AreEqual(obj, expected, ref empty))
+                var @default = Tolerance.Default;
+                var equalityComparer = new NUnitEqualityComparer();
+                if (equalityComparer.AreEqual(obj, expected, ref @default))
                     return;
             }
 
@@ -176,8 +177,9 @@ namespace Abc.Zebus.Testing.Extensions
         {
             foreach (var obj in actual)
             {
-                var empty = Tolerance.Empty;
-                if (NUnitEqualityComparer.Default.AreEqual(obj, expected, ref empty))
+                var @default = Tolerance.Default;
+                var equalityComparer = new NUnitEqualityComparer();
+                if (equalityComparer.AreEqual(obj, expected, ref @default))
                     Assert.Fail("'{0}' is present in the enumerable", expected);
             }
         }
@@ -254,12 +256,12 @@ namespace Abc.Zebus.Testing.Extensions
 
         public static void ShouldContain(this string actual, string expected)
         {
-            Assert.That(actual, Is.StringContaining(expected));
+            Assert.That(actual, Does.Contain(expected));
         }
 
         public static void ShouldContainIgnoreCase(this string actual, string expected)
         {
-            Assert.That(actual, Is.StringContaining(expected).IgnoreCase);
+            Assert.That(actual, Does.Contain(expected).IgnoreCase);
         }
 
         public static void ShouldNotContain(this string actual, string expected)

--- a/src/Abc.Zebus.Tests/Abc.Zebus.Tests.csproj
+++ b/src/Abc.Zebus.Tests/Abc.Zebus.Tests.csproj
@@ -43,7 +43,8 @@
     <PackageReference Include="log4net" Version="2.0.3" />
     <PackageReference Include="Moq" Version="4.2.1507.0118" />
     <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
-    <PackageReference Include="NUnit" Version="2.6.4" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="protobuf-net" Version="2.0.0.668" />
     <PackageReference Include="structuremap" Version="3.1.6.186" />
   </ItemGroup>

--- a/src/Abc.Zebus.Tests/Core/BusManualTests.cs
+++ b/src/Abc.Zebus.Tests/Core/BusManualTests.cs
@@ -16,7 +16,7 @@ using Timeout = ABC.ServiceBus.Contracts.Timeout;
 namespace Abc.Zebus.Tests.Core
 {
     [TestFixture]
-    [Ignore]
+    [Ignore("ManualOnly")]
     [Category("ManualOnly")]
     public class BusManualTests
     {

--- a/src/Abc.Zebus.Tests/Core/BusPerformanceTests.cs
+++ b/src/Abc.Zebus.Tests/Core/BusPerformanceTests.cs
@@ -14,7 +14,7 @@ using ProtoBuf;
 namespace Abc.Zebus.Tests.Core
 {
     [TestFixture]
-    [Ignore]
+    [Ignore("ManualOnly")]
     [Category("ManualOnly")]
     public class BusPerformanceTests
     {

--- a/src/Abc.Zebus.Tests/Directory/PeerDirectoryClientTests.Performance.cs
+++ b/src/Abc.Zebus.Tests/Directory/PeerDirectoryClientTests.Performance.cs
@@ -12,7 +12,7 @@ namespace Abc.Zebus.Tests.Directory
     public partial class PeerDirectoryClientTests
     {
         [Test]
-        [Ignore]
+        [Ignore("ManualOnly")]
         [Category("ManualOnly")]
         public void MeasureUpdatePerformance()
         {
@@ -70,7 +70,7 @@ namespace Abc.Zebus.Tests.Directory
         }
 
         [Test]
-        [Ignore]
+        [Ignore("ManualOnly")]
         [Category("ManualOnly")]
         public void MeasureUpdatePerformanceWithManyBindingKeys()
         {
@@ -94,7 +94,7 @@ namespace Abc.Zebus.Tests.Directory
         }
 
         [Test]
-        [Ignore]
+        [Ignore("ManualOnly")]
         [Category("ManualOnly")]
         public void MeasureMemoryConsumption()
         {

--- a/src/Abc.Zebus.Tests/Directory/PeerSubscriptionTreeTests.Performance.cs
+++ b/src/Abc.Zebus.Tests/Directory/PeerSubscriptionTreeTests.Performance.cs
@@ -12,7 +12,7 @@ namespace Abc.Zebus.Tests.Directory
     public partial class PeerSubscriptionTreeTests
     {
         [Test]
-        [Ignore]
+        [Ignore("ManualOnly")]
         [Category("ManualOnly")]
         [TestCase("a.e.f")]
         [TestCase("a.e")]

--- a/src/Abc.Zebus.Tests/Log4netConfigurator.cs
+++ b/src/Abc.Zebus.Tests/Log4netConfigurator.cs
@@ -11,7 +11,7 @@ namespace Abc.Zebus.Tests
     [SetUpFixture]
     public class Log4netConfigurator
     {
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
             var configurationFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "log4net.config");

--- a/src/Abc.Zebus.Tests/Routing/BindingKeyPredicateBuilderTests.cs
+++ b/src/Abc.Zebus.Tests/Routing/BindingKeyPredicateBuilderTests.cs
@@ -26,7 +26,7 @@ namespace Abc.Zebus.Tests.Routing
             predicate(expectedResult.Message).ShouldEqual(expectedResult.Result);
         }
 
-        public ExpectedResult[] TestSources { get; } = {
+        public static ExpectedResult[] TestSources { get; } = {
             new ExpectedResult(new FakeRoutableCommand(1, "toto"), new BindingKey("1", "toto", "*"), true),
             new ExpectedResult(new FakeRoutableCommand(1, "toto"), new BindingKey("*", "toto", "*"), true),
             new ExpectedResult(new FakeRoutableCommand(1, "toto"), new BindingKey("1", "*", "*"), true),

--- a/src/Abc.Zebus.Tests/Routing/BindingKeyTests.cs
+++ b/src/Abc.Zebus.Tests/Routing/BindingKeyTests.cs
@@ -49,7 +49,7 @@ namespace Abc.Zebus.Tests.Routing
         }
 
         [Test]
-        [Ignore]
+        [Ignore("ManualOnly")]
         [Category("ManualOnly")]
         public void MeasurePerformances()
         {

--- a/src/Abc.Zebus.Tests/SubscriptionTests.cs
+++ b/src/Abc.Zebus.Tests/SubscriptionTests.cs
@@ -233,7 +233,7 @@ namespace Abc.Zebus.Tests
         }
 
         [Test]
-        [Ignore]
+        [Ignore("ManualOnly")]
         [Category("ManualOnly")]
         [TestCase("a.b", "a.b.c.d")]
         [TestCase("d.*", "a.b.c.d")]

--- a/src/Abc.Zebus.Tests/Transport/ZmqTests.cs
+++ b/src/Abc.Zebus.Tests/Transport/ZmqTests.cs
@@ -7,7 +7,7 @@ using ZeroMQ;
 namespace Abc.Zebus.Tests.Transport
 {
     [TestFixture]
-    [Ignore]
+    [Ignore("ManualOnly")]
     [Category("ManualOnly")]
     public class ZmqTests
     {

--- a/src/Abc.Zebus.Tests/Transport/ZmqTransportPerformanceTests.cs
+++ b/src/Abc.Zebus.Tests/Transport/ZmqTransportPerformanceTests.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 namespace Abc.Zebus.Tests.Transport
 {
     [TestFixture]
-    [Ignore]
+    [Ignore("ManualOnly")]
     [Category("ManualOnly")]
     public class ZmqTransportPerformanceTests
     {


### PR DESCRIPTION
In order to keep being up to date ... and enable live unit testing in visual studio enterprise (without any third party extension)

I had to fix some breaking changes -> https://github.com/nunit/docs/wiki/Breaking-Changes

How cool is that !
![image](https://user-images.githubusercontent.com/1341236/37930628-4bfa0fe2-3111-11e8-87df-925ff3504811.png)
