### PR TITLE
Consistent IMessageSerializer usage

### DIFF
--- a/src/Abc.Zebus.Persistence.Tests/MessageReplayerRepositoryTests.cs
+++ b/src/Abc.Zebus.Persistence.Tests/MessageReplayerRepositoryTests.cs
@@ -2,6 +2,7 @@
 using Abc.Zebus.Persistence.Matching;
 using Abc.Zebus.Persistence.Reporter;
 using Abc.Zebus.Persistence.Storage;
+using Abc.Zebus.Serialization;
 using Abc.Zebus.Testing;
 using Abc.Zebus.Testing.Extensions;
 using Abc.Zebus.Transport;
@@ -25,7 +26,7 @@ namespace Abc.Zebus.Persistence.Tests
             var storage = new Mock<IStorage>();
             var speedReporter = new Mock<IReporter>();
 
-            _repository = new MessageReplayerRepository(persistenceConfigurationMock.Object, storage.Object, new TestBus(), transportMock.Object, batchPersisterMock.Object, speedReporter.Object);
+            _repository = new MessageReplayerRepository(persistenceConfigurationMock.Object, storage.Object, new TestBus(), transportMock.Object, batchPersisterMock.Object, speedReporter.Object, Mock.Of<IMessageSerializer>());
 
             _peer = new Peer(new PeerId("Abc.Testing.Peer.0"), "tcp://abctest:888");
         }

--- a/src/Abc.Zebus.Persistence.Tests/MessageReplayerTests.cs
+++ b/src/Abc.Zebus.Persistence.Tests/MessageReplayerTests.cs
@@ -7,6 +7,7 @@ using Abc.Zebus.Persistence.Messages;
 using Abc.Zebus.Persistence.Reporter;
 using Abc.Zebus.Persistence.Storage;
 using Abc.Zebus.Persistence.Tests.TestUtil;
+using Abc.Zebus.Serialization;
 using Abc.Zebus.Testing;
 using Abc.Zebus.Testing.Comparison;
 using Abc.Zebus.Testing.Extensions;
@@ -64,7 +65,7 @@ namespace Abc.Zebus.Persistence.Tests
 
             var speedReporter = new Mock<IReporter>();
 
-            _replayer = new MessageReplayer(_configurationMock.Object, _storageMock.Object, _bus, _transport, _messageMatcherMock.Object, _targetPeer, _replayId, speedReporter.Object);
+            _replayer = new MessageReplayer(_configurationMock.Object, _storageMock.Object, _bus, _transport, _messageMatcherMock.Object, _targetPeer, _replayId, speedReporter.Object, new MessageSerializer());
 
             _messageMatcherMock.Setup(x => x.EnqueueWaitHandle(It.IsAny<EventWaitHandle>())).Callback<EventWaitHandle>(x => x.Set());
         }

--- a/src/Abc.Zebus.Persistence/MessageReplayerRepository.cs
+++ b/src/Abc.Zebus.Persistence/MessageReplayerRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Abc.Zebus.Persistence.Matching;
 using Abc.Zebus.Persistence.Reporter;
 using Abc.Zebus.Persistence.Storage;
+using Abc.Zebus.Serialization;
 using Abc.Zebus.Transport;
 
 namespace Abc.Zebus.Persistence
@@ -16,10 +17,16 @@ namespace Abc.Zebus.Persistence
         private readonly ITransport _transport;
         private readonly IInMemoryMessageMatcher _inMemoryMessageMatcher;
         private readonly IReporter _speedReporter;
+        private readonly IMessageSerializer _messageSerializer;
         private bool _messageReplayersEnabled = true;
 
-        public MessageReplayerRepository(IPersistenceConfiguration persistenceConfiguration, IStorage storage, IBus bus, ITransport transport,
-                                         IInMemoryMessageMatcher inMemoryMessageMatcher, IReporter speedReporter)
+        public MessageReplayerRepository(IPersistenceConfiguration persistenceConfiguration,
+                                         IStorage storage,
+                                         IBus bus,
+                                         ITransport transport,
+                                         IInMemoryMessageMatcher inMemoryMessageMatcher,
+                                         IReporter speedReporter,
+                                         IMessageSerializer messageSerializer)
         {
             _persistenceConfiguration = persistenceConfiguration;
             _storage = storage;
@@ -27,6 +34,7 @@ namespace Abc.Zebus.Persistence
             _transport = transport;
             _inMemoryMessageMatcher = inMemoryMessageMatcher;
             _speedReporter = speedReporter;
+            _messageSerializer = messageSerializer;
         }
 
         public bool HasActiveMessageReplayers()
@@ -44,7 +52,7 @@ namespace Abc.Zebus.Persistence
                 ThrowIfDeactivated();
             }
 
-            return new MessageReplayer(_persistenceConfiguration, _storage, _bus, _transport, _inMemoryMessageMatcher, peer, replayId, _speedReporter);
+            return new MessageReplayer(_persistenceConfiguration, _storage, _bus, _transport, _inMemoryMessageMatcher, peer, replayId, _speedReporter, _messageSerializer);
         }
 
         public void DeactivateMessageReplayers()

--- a/src/Abc.Zebus.Tests/Dispatch/DispatchQueueTests.cs
+++ b/src/Abc.Zebus.Tests/Dispatch/DispatchQueueTests.cs
@@ -10,6 +10,7 @@ using Abc.Zebus.Testing.Dispatch;
 using Abc.Zebus.Testing.Extensions;
 using Abc.Zebus.Tests.Dispatch.DispatchMessages;
 using Abc.Zebus.Tests.Messages;
+using Abc.Zebus.Tests.Serialization;
 using Abc.Zebus.Util;
 using NUnit.Framework;
 
@@ -66,7 +67,7 @@ namespace Abc.Zebus.Tests.Dispatch
             _dispatchQueue.Start();
 
             var message1 = new ExecutableEvent { Callback = x => throw new Exception("Processing error") };
-            var dispatch = new MessageDispatch(MessageContext.CreateTest(), message1, (d, r) => throw new Exception("Continuation error"));
+            var dispatch = new MessageDispatch(MessageContext.CreateTest(), message1, new TestMessageSerializer(), (d, r) => throw new Exception("Continuation error"));
             dispatch.SetHandlerCount(1);
 
             _dispatchQueue.Enqueue(dispatch, new TestMessageHandlerInvoker<ExecutableEvent>());
@@ -269,7 +270,7 @@ namespace Abc.Zebus.Tests.Dispatch
 
             var dispatch1 = EnqueueBatchedInvocation(new ExecutableEvent { Callback = x => Throw() });
             var dispatch2 = EnqueueBatchedInvocation(new ExecutableEvent());
-            
+
             firstMessage.Unblock();
 
             (await dispatch1).Errors.ShouldNotBeEmpty();
@@ -519,7 +520,7 @@ namespace Abc.Zebus.Tests.Dispatch
         {
             var tcs = new TaskCompletionSource<DispatchResult>();
 
-            var dispatch = new MessageDispatch(MessageContext.CreateTest(), message, (d, r) => tcs.SetResult(r));
+            var dispatch = new MessageDispatch(MessageContext.CreateTest(), message, new TestMessageSerializer(), (d, r) => tcs.SetResult(r));
             dispatch.SetHandlerCount(1);
 
             var invoker = new TestMessageHandlerInvoker<ExecutableEvent>();
@@ -533,7 +534,7 @@ namespace Abc.Zebus.Tests.Dispatch
         {
             var tcs = new TaskCompletionSource<DispatchResult>();
 
-            var dispatch = new MessageDispatch(MessageContext.CreateTest(), message, (d, r) => tcs.SetResult(r));
+            var dispatch = new MessageDispatch(MessageContext.CreateTest(), message, new TestMessageSerializer(), (d, r) => tcs.SetResult(r));
             dispatch.SetHandlerCount(1);
 
             var invoker = new TestAsyncMessageHandlerInvoker<AsyncExecutableEvent>();
@@ -547,7 +548,7 @@ namespace Abc.Zebus.Tests.Dispatch
         {
             var tcs = new TaskCompletionSource<DispatchResult>();
 
-            var dispatch = new MessageDispatch(MessageContext.CreateTest(), message, (d, r) => tcs.SetResult(r));
+            var dispatch = new MessageDispatch(MessageContext.CreateTest(), message, new TestMessageSerializer(), (d, r) => tcs.SetResult(r));
             dispatch.SetHandlerCount(1);
 
             var invoker = new TestBatchedMessageHandlerInvoker<FakeEvent>();

--- a/src/Abc.Zebus.Tests/Lotus/ReplayMessageHandlerTests.cs
+++ b/src/Abc.Zebus.Tests/Lotus/ReplayMessageHandlerTests.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Reflection;
 using Abc.Zebus.Dispatch;
 using Abc.Zebus.Lotus;
-using Abc.Zebus.Testing.Dispatch;
 using Abc.Zebus.Testing.Extensions;
 using Abc.Zebus.Tests.Messages;
 using Abc.Zebus.Transport;
@@ -127,7 +126,7 @@ namespace Abc.Zebus.Tests.Lotus
         {
             public MessageDispatch CreateMessageDispatch(TransportMessage transportMessage)
             {
-                return new MessageDispatch(MessageContext.CreateNew(transportMessage), null, null);
+                return new MessageDispatch(MessageContext.CreateNew(transportMessage), null, null, null);
             }
         }
 

--- a/src/Abc.Zebus.Tests/Serialization/MessageSerializerTests.cs
+++ b/src/Abc.Zebus.Tests/Serialization/MessageSerializerTests.cs
@@ -5,6 +5,7 @@ using Abc.Zebus.Testing;
 using Abc.Zebus.Testing.Extensions;
 using Abc.Zebus.Tests.Messages;
 using NUnit.Framework;
+using ProtoBuf;
 
 namespace Abc.Zebus.Tests.Serialization
 {
@@ -55,6 +56,35 @@ namespace Abc.Zebus.Tests.Serialization
             deserializedTransportMessage.WasPersisted.ShouldEqual(transportMessage.WasPersisted);
 
             message.Targets.ShouldBeEquivalentTo(transportMessage.PersistentPeerIds);
+        }
+
+        [Test]
+        public void should_clone_serializable_message()
+        {
+            var message = new SerializableMessage { Value = 42 };
+
+            _messageSerializer.TryClone(message, out var clone).ShouldBeTrue();
+            clone.ShouldNotBeNull();
+            clone.ShouldNotBeTheSameAs(message);
+            clone.ShouldBe<SerializableMessage>().Value.ShouldEqual(message.Value);
+        }
+
+        [Test]
+        public void should_not_clone_non_serializable_message()
+        {
+            var message = new NonSerializableMessage();
+            _messageSerializer.TryClone(message, out _).ShouldBeFalse();
+        }
+
+        [ProtoContract]
+        public class SerializableMessage : IMessage
+        {
+            [ProtoMember(1)]
+            public int Value { get; set; }
+        }
+
+        public class NonSerializableMessage : IMessage
+        {
         }
     }
 }

--- a/src/Abc.Zebus.Tests/Serialization/TestMessageSerializer.cs
+++ b/src/Abc.Zebus.Tests/Serialization/TestMessageSerializer.cs
@@ -36,6 +36,9 @@ namespace Abc.Zebus.Tests.Serialization
             return _serializer.Deserialize(messageTypeId, stream);
         }
 
+        public bool TryClone(IMessage message, out IMessage clone)
+            => _serializer.TryClone(message, out clone);
+
         public Stream Serialize(IMessage message)
         {
             if (_serializationExceptions.TryGetValue(message.TypeId(), out var exception))

--- a/src/Abc.Zebus/Core/Bus.cs
+++ b/src/Abc.Zebus/Core/Bus.cs
@@ -559,7 +559,7 @@ namespace Abc.Zebus.Core
 
             var context = MessageContext.CreateNew(transportMessage);
             var continuation = GetOnRemoteMessageDispatchedContinuation(transportMessage, sendAcknowledgment);
-            return new MessageDispatch(context, message, continuation, synchronousDispatch);
+            return new MessageDispatch(context, message, _serializer, continuation, synchronousDispatch);
         }
 
         protected virtual void HandleRemoteMessage(TransportMessage transportMessage, bool synchronous = false)
@@ -669,7 +669,7 @@ namespace Abc.Zebus.Core
             _messageLogger.LogReceiveMessageLocal(message);
 
             var context = MessageContext.CreateOverride(PeerId, EndPoint);
-            var dispatch = new MessageDispatch(context, message, GetOnLocalMessageDispatchedContinuation(taskCompletionSource))
+            var dispatch = new MessageDispatch(context, message, _serializer, GetOnLocalMessageDispatchedContinuation(taskCompletionSource))
             {
                 IsLocal = true
             };

--- a/src/Abc.Zebus/Dispatch/MessageDispatch.cs
+++ b/src/Abc.Zebus/Dispatch/MessageDispatch.cs
@@ -9,13 +9,15 @@ namespace Abc.Zebus.Dispatch
     {
         private static readonly object _exceptionsLock = new object();
 
+        private readonly IMessageSerializer _messageSerializer;
         private readonly Action<MessageDispatch, DispatchResult> _continuation;
         private Dictionary<Type, Exception> _exceptions;
         private int _remainingHandlerCount;
         private bool _isCloned;
 
-        public MessageDispatch(MessageContext context, IMessage message, Action<MessageDispatch, DispatchResult> continuation, bool shouldRunSynchronously = false)
+        public MessageDispatch(MessageContext context, IMessage message, IMessageSerializer messageSerializer, Action<MessageDispatch, DispatchResult> continuation, bool shouldRunSynchronously = false)
         {
+            _messageSerializer = messageSerializer;
             _continuation = continuation;
 
             ShouldRunSynchronously = shouldRunSynchronously;
@@ -63,7 +65,7 @@ namespace Abc.Zebus.Dispatch
             if (!IsLocal || _isCloned)
                 return;
 
-            if (Serializer.TryClone(Message, out var clone))
+            if (_messageSerializer.TryClone(Message, out var clone))
                 Message = clone;
 
             _isCloned = true;

--- a/src/Abc.Zebus/Serialization/IMessageSerializer.cs
+++ b/src/Abc.Zebus/Serialization/IMessageSerializer.cs
@@ -6,5 +6,6 @@ namespace Abc.Zebus.Serialization
     {
         Stream Serialize(IMessage message);
         IMessage Deserialize(MessageTypeId messageTypeId, Stream stream);
+        bool TryClone(IMessage message, out IMessage clone);
     }
 }

--- a/src/Abc.Zebus/Serialization/MessageSerializer.cs
+++ b/src/Abc.Zebus/Serialization/MessageSerializer.cs
@@ -26,5 +26,8 @@ namespace Abc.Zebus.Serialization
 
             return stream;
         }
+
+        public bool TryClone(IMessage message, out IMessage clone)
+            => Serializer.TryClone(message, out  clone);
     }
 }


### PR DESCRIPTION
This fixes the pieces of code which bypassed `IMessageSerializer` to make the serializer customizable by providing a different implementation. All *user* messages (*not* `TransportMessage`) serialization/deserialization/cloning now goes through this interface.

 - A `IMessageSerializer.TryClone` method has been added to handle the case of a local dispatch which is either asynchronous or going to a different dispatch queue. These kind of messages do not necessarily have to be serializable so we can't simply serialize then deserialize the message - that could break existing code.
 - The persistence now also uses this interface. Note that a custom serializer needs to be able to handle the `Abc.Zebus.Persistence.MessageReplayed` message for this to work.

Fixes #83.
