### PR TITLE
Send messages with empty binding key to every peer

### DIFF
--- a/src/Abc.Zebus.Tests/Directory/PeerSubscriptionTreeTests.cs
+++ b/src/Abc.Zebus.Tests/Directory/PeerSubscriptionTreeTests.cs
@@ -71,6 +71,32 @@ namespace Abc.Zebus.Tests.Directory
             matchingPeers.Single().ShouldEqual(peer);
         }
 
+        [TestCase("*")]
+        [TestCase("#")]
+        [TestCase("foo")]
+        [TestCase("foo.#")]
+        [TestCase("foo.bar")]
+        [TestCase("foo.bar.*")]
+        [TestCase("foo.bar.#")]
+        [TestCase("foo.bar.baz")]
+        [TestCase("foo.*.baz")]
+        public void empty_bindingkey_should_return_all_subscriptions(string routingKey)
+        {
+            // Arrange
+            var peerSubscriptionTree = new PeerSubscriptionTree();
+            var peerA = new Peer(new PeerId("a"), "endpoint");
+            var peerB = new Peer(new PeerId("b"), "endpoint");
+
+            peerSubscriptionTree.Add(peerA, BindingKeyHelper.CreateFromString(routingKey, '.'));
+            peerSubscriptionTree.Add(peerB, BindingKeyHelper.CreateFromString("foo.bar", '.'));
+
+            // Act
+            var matchingPeers = peerSubscriptionTree.GetPeers(BindingKey.Empty);
+
+            // Assert
+            matchingPeers.ShouldBeEquivalentTo(peerA, peerB);
+        }
+
         [TestCase("a.b.c")]
         [TestCase("b.c.d")]
         public void stars_should_always_match_if_same_number_of_parts(string routingKey)

--- a/src/Abc.Zebus/Util/Extensions/ExtendDictionary.cs
+++ b/src/Abc.Zebus/Util/Extensions/ExtendDictionary.cs
@@ -64,5 +64,11 @@ namespace Abc.Zebus.Util.Extensions
                 dictionary.Remove(key);
             }
         }
+
+        public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> pair, out TKey key, out TValue value)
+        {
+            key = pair.Key;
+            value = pair.Value;
+        }
     }
 }


### PR DESCRIPTION
...even to peers which subscribed with a non-empty binding key.

This will ease migration when making a message routable.
Emitters that are not aware of the routing definition will send messages to all subscribing peers, irrespective of the binding key they subscribed with.

This is a behavior change, but the previous behavior was arguably less useful. Peers that subscribed with a binding key may receive messages that don't match it (there is no message filtering on static invoker dispatch), but they're already supposed to be able to handle that.
