### PR TITLE
Support adding subscriptions before the bus starts

### DIFF
--- a/src/Abc.Zebus.Testing/TestBus.cs
+++ b/src/Abc.Zebus.Testing/TestBus.cs
@@ -140,7 +140,7 @@ namespace Abc.Zebus.Testing
 
         public async Task<IDisposable> SubscribeAsync(SubscriptionRequest request)
         {
-            request.MarkAsSubmitted(0);
+            request.MarkAsSubmitted(0, IsRunning);
 
             if (request.Batch != null)
                 await request.Batch.WhenSubmittedAsync().ConfigureAwait(false);
@@ -152,7 +152,7 @@ namespace Abc.Zebus.Testing
 
         public async Task<IDisposable> SubscribeAsync(SubscriptionRequest request, Action<IMessage> handler)
         {
-            request.MarkAsSubmitted(0);
+            request.MarkAsSubmitted(0, IsRunning);
 
             if (request.Batch != null)
                 await request.Batch.WhenSubmittedAsync().ConfigureAwait(false);

--- a/src/Abc.Zebus.Testing/TestBus.cs
+++ b/src/Abc.Zebus.Testing/TestBus.cs
@@ -140,7 +140,7 @@ namespace Abc.Zebus.Testing
 
         public async Task<IDisposable> SubscribeAsync(SubscriptionRequest request)
         {
-            request.MarkAsSubmitted();
+            request.MarkAsSubmitted(0);
 
             if (request.Batch != null)
                 await request.Batch.WhenSubmittedAsync().ConfigureAwait(false);
@@ -152,7 +152,7 @@ namespace Abc.Zebus.Testing
 
         public async Task<IDisposable> SubscribeAsync(SubscriptionRequest request, Action<IMessage> handler)
         {
-            request.MarkAsSubmitted();
+            request.MarkAsSubmitted(0);
 
             if (request.Batch != null)
                 await request.Batch.WhenSubmittedAsync().ConfigureAwait(false);

--- a/src/Abc.Zebus.Tests/Core/BusTests.Subscribe.cs
+++ b/src/Abc.Zebus.Tests/Core/BusTests.Subscribe.cs
@@ -573,16 +573,16 @@ namespace Abc.Zebus.Tests.Core
                 request.AddToBatch(batch);
 
                 _bus.Start();
-                var _ = _bus.SubscribeAsync(request);
+                _ = _bus.SubscribeAsync(request);
 
                 _bus.Stop();
 
                 var submitTask = batch.SubmitAsync();
-                Assert.Throws<AggregateException>(() => submitTask.Wait()).InnerExceptions.ExpectedSingle().ShouldBe<InvalidOperationException>();
+                Assert.Throws<AggregateException>(() => submitTask.Wait(10.Seconds())).InnerExceptions.ExpectedSingle().ShouldBe<InvalidOperationException>();
             }
 
             [Test]
-            public async Task should_subscribe_when_bus_is_stopped()
+            public void should_subscribe_when_bus_is_stopped()
             {
                 var subscriptions = new List<Subscription>();
                 _directoryMock.Setup(x => x.RegisterAsync(_bus, It.Is<Peer>(p => p.DeepCompare(_self)), It.IsAny<IEnumerable<Subscription>>()))
@@ -591,12 +591,11 @@ namespace Abc.Zebus.Tests.Core
 
                 var task = _bus.SubscribeAsync(Subscription.Any<FakeCommand>());
 
-                task.IsCompleted.ShouldBeFalse();
+                task.IsCompleted.ShouldBeTrue();
                 subscriptions.ShouldBeEmpty();
 
                 _bus.Start();
 
-                await task.WithTimeoutAsync(10.Seconds());
                 subscriptions.ExpectedSingle().MessageTypeId.ShouldEqual(MessageUtil.TypeId<FakeCommand>());
             }
 

--- a/src/Abc.Zebus/Core/Bus.cs
+++ b/src/Abc.Zebus/Core/Bus.cs
@@ -505,10 +505,15 @@ namespace Abc.Zebus.Core
                         if (status.IsEmpty)
                             _subscriptions.Remove(subscription);
                     }
-                }
 
-                if (!IsRunning || request.SubmissionSubscriptionsVersion != _subscriptionsVersion)
-                    return;
+                    if (!IsRunning)
+                        return;
+                }
+                else
+                {
+                    if (!IsRunning || request.SubmissionSubscriptionsVersion != _subscriptionsVersion)
+                        return;
+                }
 
                 foreach (var subscription in request.Subscriptions)
                 {

--- a/src/Abc.Zebus/SubscriptionRequest.cs
+++ b/src/Abc.Zebus/SubscriptionRequest.cs
@@ -45,6 +45,9 @@ namespace Abc.Zebus
             IsSubmitted = true;
             SubmissionSubscriptionsVersion = subscriptionsVersion;
             IsStartupRequest = !isRunning;
+
+            if (IsStartupRequest && Batch != null)
+                throw new InvalidOperationException("Startup subscriptions should not be batched");
         }
 
         private void EnsureNotSubmitted()

--- a/src/Abc.Zebus/SubscriptionRequest.cs
+++ b/src/Abc.Zebus/SubscriptionRequest.cs
@@ -15,7 +15,7 @@ namespace Abc.Zebus
         internal SubscriptionRequestBatch? Batch { get; private set; }
 
         internal bool IsSubmitted { get; private set; }
-        internal int? SubmissionSubscriptionsVersion { get; set; }
+        internal int? SubmissionSubscriptionsVersion { get; private set; }
 
         public SubscriptionRequest(Subscription subscription)
         {
@@ -38,10 +38,11 @@ namespace Abc.Zebus
             Batch = batch;
         }
 
-        internal void MarkAsSubmitted()
+        internal void MarkAsSubmitted(int subscriptionsVersion)
         {
             EnsureNotSubmitted();
             IsSubmitted = true;
+            SubmissionSubscriptionsVersion = subscriptionsVersion;
         }
 
         private void EnsureNotSubmitted()

--- a/src/Abc.Zebus/SubscriptionRequest.cs
+++ b/src/Abc.Zebus/SubscriptionRequest.cs
@@ -16,6 +16,7 @@ namespace Abc.Zebus
 
         internal bool IsSubmitted { get; private set; }
         internal int? SubmissionSubscriptionsVersion { get; private set; }
+        internal bool IsStartupRequest { get; private set; }
 
         public SubscriptionRequest(Subscription subscription)
         {
@@ -38,11 +39,12 @@ namespace Abc.Zebus
             Batch = batch;
         }
 
-        internal void MarkAsSubmitted(int subscriptionsVersion)
+        internal void MarkAsSubmitted(int subscriptionsVersion, bool isRunning)
         {
             EnsureNotSubmitted();
             IsSubmitted = true;
             SubmissionSubscriptionsVersion = subscriptionsVersion;
+            IsStartupRequest = !isRunning;
         }
 
         private void EnsureNotSubmitted()


### PR DESCRIPTION
Part of #99 

This lets you call `Subscribe`/`SubscribeAsync` when the bus is stopped. These subscriptions are treated in a special way and are applied _each time_ the bus is started.

We may still fine tune the details:
 - Currently the bus behaves as if `ThereIsNoHandlerButIKnowWhatIAmDoing` were true in order to avoid eagerly loading the handlers. We may require this option to be set to `true` in order to proceed, but that would seem strange if a handler actually exists.
 - Or we could add a new option to `SubscriptionRequest` to make the intent more explicit. That would mean we would continue to throw on "normal" subscription requests when the bus is stopped. Also, the new option would allow to create these persistent subscriptions even after the bus is started.
 - Currently requests made after the bus is stopped are treated the same as requests made before it is started. We could consider these kinds of requests are only valid on initialization and disallow them after the first time the bus is started.
 - `SubscribeAsync` returns a completed task when the bus is stopped. This lets you use `Subscribe` instead without causing a deadlock.



