### PR TITLE
Support auto-subscribe routable message

### DIFF
--- a/src/Abc.Zebus.Contracts/Routing/Routable.cs
+++ b/src/Abc.Zebus.Contracts/Routing/Routable.cs
@@ -2,8 +2,28 @@
 
 namespace Abc.Zebus.Routing
 {
+    /// <summary>
+    /// Indicates that the target message is routable.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A routable message must have routable members. The routable members must be explicitly specified using <see cref="RoutingPositionAttribute"/>.
+    /// </para>
+    /// <para>
+    /// The default subscription mode of routable message is <c>Manual</c>, i.e.: subscriptions must be manually created with <c>IBus.Subscribe</c>.
+    /// If you update an existing message to make it routable, consider specifying <c>AutoSubscribe = true</c> to keep previous subscription mode.
+    /// </para>
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class Routable : Attribute
     {
+        /// <summary>
+        /// Indicates whether the default subscription mode for the target message is Auto (<c>AutoSubscribe == true</c>) or Manual.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="AutoSubscribe"/> configures the default subscription mode for the target message. The subscription mode
+        /// can still be overriden per message handler using the <c>SubscriptionMode</c> attribute.
+        /// </remarks>
+        public bool AutoSubscribe { get; set; }
     }
 }

--- a/src/Abc.Zebus.Tests/Dispatch/MessageHandlerInvokerSubscriberTests.cs
+++ b/src/Abc.Zebus.Tests/Dispatch/MessageHandlerInvokerSubscriberTests.cs
@@ -13,10 +13,13 @@ namespace Abc.Zebus.Tests.Dispatch
     {
         [TestCase(typeof(DefaultHandler), typeof(Event), SubscriptionMode.Auto)]
         [TestCase(typeof(DefaultHandler), typeof(RoutableEvent), SubscriptionMode.Manual)]
+        [TestCase(typeof(DefaultHandler), typeof(AutoSubscribeRoutableEvent), SubscriptionMode.Auto)]
         [TestCase(typeof(ManualHandler), typeof(Event), SubscriptionMode.Manual)]
         [TestCase(typeof(ManualHandler), typeof(RoutableEvent), SubscriptionMode.Manual)]
+        [TestCase(typeof(ManualHandler), typeof(AutoSubscribeRoutableEvent), SubscriptionMode.Manual)]
         [TestCase(typeof(AutoHandler), typeof(Event), SubscriptionMode.Auto)]
         [TestCase(typeof(AutoHandler), typeof(RoutableEvent), SubscriptionMode.Auto)]
+        [TestCase(typeof(AutoHandler), typeof(AutoSubscribeRoutableEvent), SubscriptionMode.Auto)]
         public void should_get_default_subscription_mode(Type handlerType, Type messageType, SubscriptionMode expectedSubscriptionMode)
         {
             // Arrange
@@ -42,41 +45,60 @@ namespace Abc.Zebus.Tests.Dispatch
             public int Key { get; set; }
         }
 
+        [Routable(AutoSubscribe = true)]
+        public class AutoSubscribeRoutableEvent : IEvent
+        {
+            [RoutingPosition(1)]
+            public int Key { get; set; }
+        }
+
         public class Event : IEvent
         {
         }
 
-        public class DefaultHandler : IMessageHandler<RoutableEvent>, IMessageHandler<Event>
+        public class DefaultHandler : IMessageHandler<RoutableEvent>, IMessageHandler<Event>, IMessageHandler<AutoSubscribeRoutableEvent>
         {
             public void Handle(RoutableEvent message)
             {
             }
 
             public void Handle(Event message)
+            {
+            }
+
+            public void Handle(AutoSubscribeRoutableEvent message)
             {
             }
         }
 
         [SubscriptionMode(SubscriptionMode.Manual)]
-        public class ManualHandler : IMessageHandler<RoutableEvent>, IMessageHandler<Event>
+        public class ManualHandler : IMessageHandler<RoutableEvent>, IMessageHandler<Event>, IMessageHandler<AutoSubscribeRoutableEvent>
         {
             public void Handle(RoutableEvent message)
             {
             }
 
             public void Handle(Event message)
+            {
+            }
+
+            public void Handle(AutoSubscribeRoutableEvent message)
             {
             }
         }
 
         [SubscriptionMode(SubscriptionMode.Auto)]
-        public class AutoHandler : IMessageHandler<RoutableEvent>, IMessageHandler<Event>
+        public class AutoHandler : IMessageHandler<RoutableEvent>, IMessageHandler<Event>, IMessageHandler<AutoSubscribeRoutableEvent>
         {
             public void Handle(RoutableEvent message)
             {
             }
 
             public void Handle(Event message)
+            {
+            }
+
+            public void Handle(AutoSubscribeRoutableEvent message)
             {
             }
         }

--- a/src/Abc.Zebus.Tests/Scan/SyncMessageHandlerInvokerLoaderTests.cs
+++ b/src/Abc.Zebus.Tests/Scan/SyncMessageHandlerInvokerLoaderTests.cs
@@ -47,6 +47,34 @@ namespace Abc.Zebus.Tests.Scan
         }
 
         [Test]
+        public void should_subscribe_to_auto_subscribe_routable_message_handler_on_startup()
+        {
+            var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
+            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<FakeRoutableMessageWithAutoSubscribeHandler>()).ExpectedSingle();
+
+            invoker.GetStartupSubscriptions().ShouldBeEquivalentTo(Subscription.Any<FakeRoutableMessageWithAutoSubscribe>());
+        }
+
+        [Test]
+        public void should_subscribe_to_auto_subscribe_routable_message_handler_with_auto_subscription_mode_on_startup()
+        {
+            var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
+            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<FakeRoutableMessageWithAutoSubscribeHandler_Auto>()).ExpectedSingle();
+
+            invoker.GetStartupSubscriptions().ShouldBeEquivalentTo(Subscription.Any<FakeRoutableMessageWithAutoSubscribe>());
+        }
+
+
+        [Test]
+        public void should_not_subscribe_to_auto_subscribe_routable_message_handler_with_manual_subscription_mode_on_startup()
+        {
+            var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
+            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<FakeRoutableMessageWithAutoSubscribeHandler_Manual>()).ExpectedSingle();
+
+            invoker.GetStartupSubscriptions().ShouldBeEmpty();
+        }
+
+        [Test]
         public void should_switch_to_manual_subscription_mode_when_specified()
         {
             var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
@@ -104,6 +132,14 @@ namespace Abc.Zebus.Tests.Scan
             public string Key;
         }
 
+
+        [Routable(AutoSubscribe = true)]
+        public class FakeRoutableMessageWithAutoSubscribe : IMessage
+        {
+            [RoutingPosition(1)]
+            public string Key;
+        }
+
         public class FakeHandler : IMessageHandler<FakeMessage>, IMessageHandler<FakeMessage2>
         {
             public void Handle(FakeMessage message)
@@ -155,6 +191,30 @@ namespace Abc.Zebus.Tests.Scan
             {
             }
         }
+
+        public class FakeRoutableMessageWithAutoSubscribeHandler : IMessageHandler<FakeRoutableMessageWithAutoSubscribe>
+        {
+            public void Handle(FakeRoutableMessageWithAutoSubscribe message)
+            {
+            }
+        }
+
+        [SubscriptionMode(SubscriptionMode.Auto)]
+        public class FakeRoutableMessageWithAutoSubscribeHandler_Auto : IMessageHandler<FakeRoutableMessageWithAutoSubscribe>
+        {
+            public void Handle(FakeRoutableMessageWithAutoSubscribe message)
+            {
+            }
+        }
+
+        [SubscriptionMode(SubscriptionMode.Manual)]
+        public class FakeRoutableMessageWithAutoSubscribeHandler_Manual : IMessageHandler<FakeRoutableMessageWithAutoSubscribe>
+        {
+            public void Handle(FakeRoutableMessageWithAutoSubscribe message)
+            {
+            }
+        }
+
 
         [SubscriptionMode(typeof(StartupSubscriber))]
         public class FakeRoutableHandlerWithStartupSubscriber : IMessageHandler<FakeRoutableMessage>

--- a/src/Abc.Zebus.Tests/Scan/SyncMessageHandlerInvokerLoaderTests.cs
+++ b/src/Abc.Zebus.Tests/Scan/SyncMessageHandlerInvokerLoaderTests.cs
@@ -18,7 +18,7 @@ namespace Abc.Zebus.Tests.Scan
         public void should_load_queue_name()
         {
             var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
-            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<FakeHandlerWithQueueName1>()).ExpectedSingle();
+            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<TestHandler_DispatchQueue1>()).ExpectedSingle();
 
             invoker.DispatchQueueName.ShouldEqual("DispatchQueue1");
         }
@@ -27,7 +27,7 @@ namespace Abc.Zebus.Tests.Scan
         public void should_subscribe_to_standard_handler_on_startup()
         {
             var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
-            var invokers = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<FakeHandler>()).ToList();
+            var invokers = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<TestHandler>()).ToList();
 
             invokers.ShouldHaveSize(2);
 
@@ -41,7 +41,7 @@ namespace Abc.Zebus.Tests.Scan
         public void should_not_subscribe_to_routable_handler_on_startup()
         {
             var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
-            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<FakeRoutableHandler>()).ExpectedSingle();
+            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<TestRoutableHandler>()).ExpectedSingle();
 
             invoker.GetStartupSubscriptions().ShouldBeEmpty();
         }
@@ -50,18 +50,18 @@ namespace Abc.Zebus.Tests.Scan
         public void should_subscribe_to_auto_subscribe_routable_message_handler_on_startup()
         {
             var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
-            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<FakeRoutableMessageWithAutoSubscribeHandler>()).ExpectedSingle();
+            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<TestAutoSubscribeRoutableHandler>()).ExpectedSingle();
 
-            invoker.GetStartupSubscriptions().ShouldBeEquivalentTo(Subscription.Any<FakeRoutableMessageWithAutoSubscribe>());
+            invoker.GetStartupSubscriptions().ShouldBeEquivalentTo(Subscription.Any<TestAutoSubscribeRoutableMessage>());
         }
 
         [Test]
         public void should_subscribe_to_auto_subscribe_routable_message_handler_with_auto_subscription_mode_on_startup()
         {
             var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
-            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<FakeRoutableMessageWithAutoSubscribeHandler_Auto>()).ExpectedSingle();
+            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<TestAutoSubscribeRoutableHandler_AutoSubscriptionMode>()).ExpectedSingle();
 
-            invoker.GetStartupSubscriptions().ShouldBeEquivalentTo(Subscription.Any<FakeRoutableMessageWithAutoSubscribe>());
+            invoker.GetStartupSubscriptions().ShouldBeEquivalentTo(Subscription.Any<TestAutoSubscribeRoutableMessage>());
         }
 
 
@@ -69,7 +69,7 @@ namespace Abc.Zebus.Tests.Scan
         public void should_not_subscribe_to_auto_subscribe_routable_message_handler_with_manual_subscription_mode_on_startup()
         {
             var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
-            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<FakeRoutableMessageWithAutoSubscribeHandler_Manual>()).ExpectedSingle();
+            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<TestAutoSubscribeRoutableHandler_ManualSubscriptionMode>()).ExpectedSingle();
 
             invoker.GetStartupSubscriptions().ShouldBeEmpty();
         }
@@ -78,7 +78,7 @@ namespace Abc.Zebus.Tests.Scan
         public void should_switch_to_manual_subscription_mode_when_specified()
         {
             var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
-            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<FakeHandlerWithManualSubscriptionMode>()).ExpectedSingle();
+            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<TestHandler_ManualSubscriptionMode>()).ExpectedSingle();
 
             invoker.GetStartupSubscriptions().ShouldBeEmpty();
         }
@@ -87,9 +87,9 @@ namespace Abc.Zebus.Tests.Scan
         public void should_switch_to_auto_subscription_mode_when_specified()
         {
             var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
-            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<FakeRoutableHandlerWithAutoSubscriptionMode>()).ExpectedSingle();
+            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<TestRoutableHandler_AutoSubscriptionMode>()).ExpectedSingle();
 
-            var expectedSubscription = Subscription.Any<FakeRoutableMessage>();
+            var expectedSubscription = Subscription.Any<TestRoutableMessage>();
             invoker.GetStartupSubscriptions().ShouldBeEquivalentTo(expectedSubscription);
         }
 
@@ -97,9 +97,9 @@ namespace Abc.Zebus.Tests.Scan
         public void should_use_startup_subscriber()
         {
             var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
-            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<FakeRoutableHandlerWithStartupSubscriber>()).ExpectedSingle();
+            var invoker = invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<TestRoutableHandler_StartupSubscriber>()).ExpectedSingle();
 
-            var expectedSubscription = new Subscription(MessageUtil.TypeId<FakeRoutableMessage>(), new BindingKey("123"));
+            var expectedSubscription = new Subscription(MessageUtil.TypeId<TestRoutableMessage>(), new BindingKey("123"));
             invoker.GetStartupSubscriptions().ShouldBeEquivalentTo(expectedSubscription);
         }
 
@@ -114,19 +114,19 @@ namespace Abc.Zebus.Tests.Scan
         public void should_not_throw_if_scanning_handler_with_several_handle_methods()
         {
             var invokerLoader = new SyncMessageHandlerInvokerLoader(new Container());
-            Assert.DoesNotThrow(() => invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<FakeHandler>()).ToList());
+            Assert.DoesNotThrow(() => invokerLoader.LoadMessageHandlerInvokers(TypeSource.FromType<TestHandler>()).ToList());
         }
 
-        public class FakeMessage : IMessage
+        public class TestMessage1 : IMessage
         {
         }
 
-        public class FakeMessage2 : IMessage
+        public class TestMessage2 : IMessage
         {
         }
 
         [Routable]
-        public class FakeRoutableMessage : IMessage
+        public class TestRoutableMessage : IMessage
         {
             [RoutingPosition(1)]
             public string Key;
@@ -134,92 +134,92 @@ namespace Abc.Zebus.Tests.Scan
 
 
         [Routable(AutoSubscribe = true)]
-        public class FakeRoutableMessageWithAutoSubscribe : IMessage
+        public class TestAutoSubscribeRoutableMessage : IMessage
         {
             [RoutingPosition(1)]
             public string Key;
         }
 
-        public class FakeHandler : IMessageHandler<FakeMessage>, IMessageHandler<FakeMessage2>
+        public class TestHandler : IMessageHandler<TestMessage1>, IMessageHandler<TestMessage2>
         {
-            public void Handle(FakeMessage message)
+            public void Handle(TestMessage1 message)
             {
                 throw new NotImplementedException();
             }
 
-            public void Handle(FakeMessage2 message)
+            public void Handle(TestMessage2 message)
             {
                 throw new NotImplementedException();
             }
         }
 
-        public class WrongAsyncHandler : IMessageHandler<FakeMessage>
+        public class WrongAsyncHandler : IMessageHandler<TestMessage1>
         {
-            public async void Handle(FakeMessage message)
+            public async void Handle(TestMessage1 message)
             {
                 await Task.CompletedTask;
             }
         }
 
         [DispatchQueueName("DispatchQueue1")]
-        public class FakeHandlerWithQueueName1 : IMessageHandler<FakeMessage>
+        public class TestHandler_DispatchQueue1 : IMessageHandler<TestMessage1>
         {
-            public void Handle(FakeMessage message)
+            public void Handle(TestMessage1 message)
             {
             }
         }
 
         [SubscriptionMode(SubscriptionMode.Manual)]
-        public class FakeHandlerWithManualSubscriptionMode : IMessageHandler<FakeMessage>
+        public class TestHandler_ManualSubscriptionMode : IMessageHandler<TestMessage1>
         {
-            public void Handle(FakeMessage message)
+            public void Handle(TestMessage1 message)
             {
             }
         }
 
         [SubscriptionMode(SubscriptionMode.Auto)]
-        public class FakeRoutableHandlerWithAutoSubscriptionMode : IMessageHandler<FakeRoutableMessage>
+        public class TestRoutableHandler_AutoSubscriptionMode : IMessageHandler<TestRoutableMessage>
         {
-            public void Handle(FakeRoutableMessage message)
+            public void Handle(TestRoutableMessage message)
             {
             }
         }
 
-        public class FakeRoutableHandler : IMessageHandler<FakeRoutableMessage>
+        public class TestRoutableHandler : IMessageHandler<TestRoutableMessage>
         {
-            public void Handle(FakeRoutableMessage message)
+            public void Handle(TestRoutableMessage message)
             {
             }
         }
 
-        public class FakeRoutableMessageWithAutoSubscribeHandler : IMessageHandler<FakeRoutableMessageWithAutoSubscribe>
+        public class TestAutoSubscribeRoutableHandler : IMessageHandler<TestAutoSubscribeRoutableMessage>
         {
-            public void Handle(FakeRoutableMessageWithAutoSubscribe message)
+            public void Handle(TestAutoSubscribeRoutableMessage message)
             {
             }
         }
 
         [SubscriptionMode(SubscriptionMode.Auto)]
-        public class FakeRoutableMessageWithAutoSubscribeHandler_Auto : IMessageHandler<FakeRoutableMessageWithAutoSubscribe>
+        public class TestAutoSubscribeRoutableHandler_AutoSubscriptionMode : IMessageHandler<TestAutoSubscribeRoutableMessage>
         {
-            public void Handle(FakeRoutableMessageWithAutoSubscribe message)
+            public void Handle(TestAutoSubscribeRoutableMessage message)
             {
             }
         }
 
         [SubscriptionMode(SubscriptionMode.Manual)]
-        public class FakeRoutableMessageWithAutoSubscribeHandler_Manual : IMessageHandler<FakeRoutableMessageWithAutoSubscribe>
+        public class TestAutoSubscribeRoutableHandler_ManualSubscriptionMode : IMessageHandler<TestAutoSubscribeRoutableMessage>
         {
-            public void Handle(FakeRoutableMessageWithAutoSubscribe message)
+            public void Handle(TestAutoSubscribeRoutableMessage message)
             {
             }
         }
 
 
         [SubscriptionMode(typeof(StartupSubscriber))]
-        public class FakeRoutableHandlerWithStartupSubscriber : IMessageHandler<FakeRoutableMessage>
+        public class TestRoutableHandler_StartupSubscriber : IMessageHandler<TestRoutableMessage>
         {
-            public void Handle(FakeRoutableMessage message)
+            public void Handle(TestRoutableMessage message)
             {
             }
 

--- a/src/Abc.Zebus/Dispatch/MessageHandlerInvokerSubscriber.cs
+++ b/src/Abc.Zebus/Dispatch/MessageHandlerInvokerSubscriber.cs
@@ -66,7 +66,10 @@ namespace Abc.Zebus.Dispatch
 
         private static SubscriptionMode DefaultSubscriptionMode(Type messageType)
         {
-            return Attribute.IsDefined(messageType, typeof(Routable)) ? SubscriptionMode.Manual : SubscriptionMode.Auto;
+            if (Attribute.GetCustomAttribute(messageType, typeof(Routable), true) is Routable { AutoSubscribe: false })
+                return SubscriptionMode.Manual;
+
+            return SubscriptionMode.Auto;
         }
 
         private IEnumerable<Subscription> GetSubscriptionsFromMode(SubscriptionMode subscriptionMode, MessageTypeId messageTypeId)


### PR DESCRIPTION
The default subscription mode of routable message is Manual. This behavior has two issues: it breaks the principle of least surprise and it makes turning existing message routable a dangerous operation.

Changing this behavior now is not possible, but it would be nice to configure new routable messages with the Auto subscription mode.

This change allows to configure the default subscription mode of routable messages.

Another option would be to add a new independent attribute that could be available for both routable and non-routable messages. In my view, configuring the subscription mode of non-routable messages is not really valuable and adding properties and comments directly to the routable attribute will help developers to avoid errors.