### PR TITLE
Update NUnit to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   BUILD_DOTNET_VERSION: 9.0.x
-  BUILD_LINUX_TEST_TFM: net6.0
+  BUILD_LINUX_TEST_TFM: net9.0
   DOTNET_NOLOGO: 1
 
 jobs:

--- a/src/Abc.Zebus.Directory.Cassandra.Tests/Abc.Zebus.Directory.Cassandra.Tests.csproj
+++ b/src/Abc.Zebus.Directory.Cassandra.Tests/Abc.Zebus.Directory.Cassandra.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net9.0</TargetFrameworks>
     <Version>$(ZebusDirectoryVersion)</Version>
   </PropertyGroup>
 

--- a/src/Abc.Zebus.Directory.RocksDb.Tests/Abc.Zebus.Directory.RocksDb.Tests.csproj
+++ b/src/Abc.Zebus.Directory.RocksDb.Tests/Abc.Zebus.Directory.RocksDb.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net9.0</TargetFrameworks>
     <Platform>x64</Platform>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>

--- a/src/Abc.Zebus.Directory.Runner/Abc.Zebus.Directory.Runner.csproj
+++ b/src/Abc.Zebus.Directory.Runner/Abc.Zebus.Directory.Runner.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <Version>$(ZebusDirectoryVersion)</Version>
     <IsPackable>false</IsPackable>

--- a/src/Abc.Zebus.Directory.Tests/Abc.Zebus.Directory.Tests.csproj
+++ b/src/Abc.Zebus.Directory.Tests/Abc.Zebus.Directory.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net9.0</TargetFrameworks>
     <Version>$(ZebusDirectoryVersion)</Version>
   </PropertyGroup>
 

--- a/src/Abc.Zebus.Persistence.Cassandra.Tests/Abc.Zebus.Persistence.Cassandra.Tests.csproj
+++ b/src/Abc.Zebus.Persistence.Cassandra.Tests/Abc.Zebus.Persistence.Cassandra.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net9.0</TargetFrameworks>
     <Version>$(ZebusPersistenceVersion)</Version>
     <RootNamespace>Abc.Zebus.Persistence.Cassandra.Tests</RootNamespace>
   </PropertyGroup>

--- a/src/Abc.Zebus.Persistence.RocksDb.Tests/Abc.Zebus.Persistence.RocksDb.Tests.csproj
+++ b/src/Abc.Zebus.Persistence.RocksDb.Tests/Abc.Zebus.Persistence.RocksDb.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net9.0</TargetFrameworks>
     <Version>$(ZebusPersistenceVersion)</Version>
     <Platform>x64</Platform>
     <Platforms>AnyCPU;x64</Platforms>

--- a/src/Abc.Zebus.Persistence.Runner/Abc.Zebus.Persistence.Runner.csproj
+++ b/src/Abc.Zebus.Persistence.Runner/Abc.Zebus.Persistence.Runner.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <Version>$(ZebusPersistenceVersion)</Version>
     <IsPackable>false</IsPackable>

--- a/src/Abc.Zebus.Persistence.Tests/Abc.Zebus.Persistence.Tests.csproj
+++ b/src/Abc.Zebus.Persistence.Tests/Abc.Zebus.Persistence.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net9.0</TargetFrameworks>
     <Version>$(ZebusPersistenceVersion)</Version>
   </PropertyGroup>
 

--- a/src/Abc.Zebus.Testing/Abc.Zebus.Testing.csproj
+++ b/src/Abc.Zebus.Testing/Abc.Zebus.Testing.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="CompareNETObjects" Version="4.71.0" />
     <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="System.Management" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Abc.Zebus.Testing/Abc.Zebus.Testing.csproj
+++ b/src/Abc.Zebus.Testing/Abc.Zebus.Testing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <PackageId>Zebus.Testing</PackageId>
     <Description>Test tools for Zebus</Description>
     <Version>$(ZebusTestingVersion)</Version>

--- a/src/Abc.Zebus.Testing/Abc.Zebus.Testing.csproj
+++ b/src/Abc.Zebus.Testing/Abc.Zebus.Testing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <PackageId>Zebus.Testing</PackageId>
     <Description>Test tools for Zebus</Description>
     <Version>$(ZebusTestingVersion)</Version>
@@ -14,7 +14,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="CompareNETObjects" Version="4.71.0" />
     <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.3.0" />
     <PackageReference Include="System.Management" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Abc.Zebus.Testing/Extensions/NUnitExtensions.cs
+++ b/src/Abc.Zebus.Testing/Extensions/NUnitExtensions.cs
@@ -19,31 +19,25 @@ internal delegate void MethodThatThrows();
 internal static class NUnitExtensions
 {
     public static void ShouldBeFalse(this bool condition, string? message = null)
-    {
-        Assert.IsFalse(condition, message);
-    }
+        => Assert.That(condition, Is.False, message);
 
     public static void ShouldBeTrue(this bool condition, string? message = null)
-    {
-        Assert.IsTrue(condition, message);
-    }
+        => Assert.That(condition, Is.True, message);
 
     public static object ShouldEqual(this object actual, object expected, string? message = null)
     {
-        Assert.AreEqual(expected, actual, message);
+        Assert.That(actual, Is.EqualTo(expected), message);
         return expected;
     }
 
     public static object ShouldEqual(this IEnumerable actual, IEnumerable expected)
     {
-        CollectionAssert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected).AsCollection);
         return expected;
     }
 
     public static void ShouldEqualOneOf<T>(this T actual, params T[] expected)
-    {
-        Assert.That(new[] { actual }, Is.SubsetOf(expected));
-    }
+        => Assert.That(new[] { actual }, Is.SubsetOf(expected));
 
     public static object ShouldEqualDeeply(this object actual, object expected)
     {
@@ -51,7 +45,7 @@ internal static class NUnitExtensions
         var result = comparer.Compare(actual, expected);
         if (!result.AreEqual)
             Console.WriteLine(result.DifferencesString);
-        Assert.IsTrue(result.AreEqual);
+        Assert.That(result.AreEqual, Is.True);
         return expected;
     }
 
@@ -76,77 +70,66 @@ internal static class NUnitExtensions
     public static object ShouldEqualEpsilon(this decimal actual, decimal expected, decimal epsilon)
     {
         Assert.That(actual, Is.EqualTo(expected).Within(epsilon));
-
         return expected;
     }
 
     public static object? ShouldEqualEpsilon(this decimal? actual, decimal? expected, decimal epsilon)
     {
         Assert.That(actual, Is.EqualTo(expected).Within(epsilon));
-
         return expected;
     }
 
     public static object? ShouldEqualEpsilon(this decimal actual, decimal? expected, decimal epsilon)
     {
         Assert.That(actual, Is.EqualTo(expected).Within(epsilon));
-
         return expected;
     }
 
     public static object ShouldEqualEpsilon(this double actual, double expected, double epsilon)
     {
         Assert.That(actual, Is.EqualTo(expected).Within(epsilon));
-
         return expected;
     }
 
     public static object? ShouldEqualEpsilon(this double? actual, double? expected, double epsilon)
     {
         Assert.That(actual, Is.EqualTo(expected).Within(epsilon));
-
         return expected;
     }
 
     public static object ShouldNotEqual(this object actual, object expected)
     {
-        Assert.AreNotEqual(expected, actual);
+        Assert.That(actual, Is.Not.EqualTo(expected));
         return expected;
     }
 
     public static void ShouldBeNull(this object? anObject, string? message = null)
-    {
-        Assert.IsNull(anObject, message);
-    }
+        => Assert.That(anObject, Is.Null, message);
 
     [ContractAnnotation("anObject: null => halt")]
     public static void ShouldNotBeNull(this object? anObject, string? message = null)
-    {
-        Assert.IsNotNull(anObject, message);
-    }
+        => Assert.That(anObject, Is.Not.Null, message);
 
     public static object ShouldBeTheSameAs(this object actual, object expected)
     {
-        Assert.AreSame(expected, actual);
+        Assert.That(actual, Is.SameAs(expected));
         return expected;
     }
 
     public static object ShouldNotBeTheSameAs(this object actual, object expected)
     {
-        Assert.AreNotSame(expected, actual);
+        Assert.That(actual, Is.Not.SameAs(expected));
         return expected;
     }
 
     public static T ShouldBe<T>(this object? actual)
     {
-        Assert.IsInstanceOf<T>(actual);
+        Assert.That(actual, Is.InstanceOf<T>());
         return (T)actual!;
     }
 
     public static void ShouldNotBeOfType<T>(this object? actual)
-    {
-        Assert.IsNotInstanceOf<T>(actual);
-    }
+        => Assert.That(actual, Is.Not.InstanceOf<T>());
 
     public static void ShouldContain(this IEnumerable actual, object expected)
     {
@@ -157,7 +140,7 @@ internal static class NUnitExtensions
                 return;
         }
 
-        Assert.Fail("'{0}' is not present in the enumerable", expected);
+        Assert.Fail($"'{expected}' is not present in the enumerable");
     }
 
     public static void ShouldContain<T>(this IEnumerable<T> actual, Expression<Func<T, bool>> predicate)
@@ -178,14 +161,12 @@ internal static class NUnitExtensions
         {
             var empty = Tolerance.Default;
             if (new NUnitEqualityComparer().AreEqual(obj, expected, ref empty))
-                Assert.Fail("'{0}' is present in the enumerable", expected);
+                Assert.Fail($"'{expected}' is present in the enumerable");
         }
     }
 
     public static void ShouldBeEquivalentTo<T>(this IEnumerable<T> collection, params T[] expected)
-    {
-        ShouldBeEquivalentTo((IEnumerable)collection, expected);
-    }
+        => ShouldBeEquivalentTo((IEnumerable)collection, expected);
 
     public static void ShouldBeEquivalentTo(this IEnumerable collection, IEnumerable expected, bool compareDeeply = false)
     {
@@ -195,83 +176,67 @@ internal static class NUnitExtensions
             collection.ShouldBeEquivalentTo(expected, (a, b) => compareLogic.Compare(a, b).AreEqual);
         }
         else
+        {
             Assert.That(collection, Is.EquivalentTo(expected));
+        }
     }
 
     public static void ShouldBeOrdered(this IEnumerable collection)
-    {
-        Assert.That(collection, Is.Ordered);
-    }
+        => Assert.That(collection, Is.Ordered);
 
     public static void ShouldBeEquivalentTo(this IEnumerable collection, IEnumerable expected, Func<object?, object?, bool> comparer)
-    {
-        Assert.That(collection, Is.EquivalentTo(expected).Using(new EqualityComparer(comparer)));
-    }
+        => Assert.That(collection, Is.EquivalentTo(expected).Using(new EqualityComparer(comparer)));
 
     public static IComparable ShouldBeGreaterThan(this IComparable arg1, IComparable arg2)
     {
-        Assert.Greater(arg1, arg2);
+        Assert.That(arg1, Is.GreaterThan(arg2));
         return arg2;
     }
 
     public static IComparable ShouldBeGreaterOrEqualThan(this IComparable arg1, IComparable arg2)
     {
-        Assert.GreaterOrEqual(arg1, arg2);
+        Assert.That(arg1, Is.GreaterThanOrEqualTo(arg2));
         return arg2;
     }
 
     public static IComparable ShouldBeLessOrEqualThan(this IComparable arg1, IComparable arg2, string? message = null)
     {
-        Assert.LessOrEqual(arg1, arg2, message);
+        Assert.That(arg1, Is.LessThanOrEqualTo(arg2), message);
         return arg2;
     }
 
     public static IComparable ShouldBeLessThan(this IComparable arg1, IComparable arg2)
     {
-        Assert.Less(arg1, arg2);
+        Assert.That(arg1, Is.LessThan(arg2));
         return arg2;
     }
 
     public static void ShouldBeEmpty<T>(this IEnumerable<T> enumerable, string? message = null)
-    {
-        Assert.IsFalse(enumerable.Any(), message ?? "the collection is not empty");
-    }
+        => Assert.That(enumerable.Any(), Is.False, message ?? "the collection is not empty");
 
     public static void ShouldNotBeEmpty<T>(this IEnumerable<T> enumerable, string? message = null)
-    {
-        Assert.IsTrue(enumerable.Any(), message ?? "the collection is empty");
-    }
+        => Assert.That(enumerable.Any(), Is.True, message ?? "the collection is empty");
 
     public static void ShouldBeEmpty(this string aString)
-    {
-        Assert.IsEmpty(aString);
-    }
+        => Assert.That(aString, Is.Empty);
 
     public static void ShouldNotBeEmpty(this IEnumerable collection, string? message = null)
-    {
-        Assert.IsNotEmpty(collection, message);
-    }
+        => Assert.That(collection, Is.Not.Empty, message);
 
     public static void ShouldNotBeEmpty(this string aString)
-    {
-        Assert.IsNotEmpty(aString);
-    }
+        => Assert.That(aString, Is.Not.Empty);
 
     public static void ShouldContain(this string actual, string expected)
-    {
-        Assert.That(actual, Does.Contain(expected));
-    }
+        => Assert.That(actual, Does.Contain(expected));
 
     public static void ShouldContainIgnoreCase(this string actual, string expected)
-    {
-        Assert.That(actual, Does.Contain(expected).IgnoreCase);
-    }
+        => Assert.That(actual, Does.Contain(expected).IgnoreCase);
 
     public static void ShouldNotContain(this string actual, string expected)
     {
         try
         {
-            StringAssert.Contains(expected, actual);
+            Assert.That(actual, Does.Contain(expected));
         }
         catch (AssertionException)
         {
@@ -283,51 +248,47 @@ internal static class NUnitExtensions
 
     public static string ShouldBeEqualIgnoringCase(this string actual, string expected)
     {
-        StringAssert.AreEqualIgnoringCase(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected).IgnoreCase);
         return expected;
     }
 
     public static void ShouldStartWith(this string actual, string expected)
-    {
-        StringAssert.StartsWith(expected, actual);
-    }
+        => Assert.That(actual, Does.StartWith(expected));
 
     public static void ShouldEndWith(this string actual, string expected)
-    {
-        StringAssert.EndsWith(expected, actual);
-    }
+        => Assert.That(actual, Does.EndWith(expected));
 
     public static void ShouldBeSurroundedWith(this string actual, string expectedStartDelimiter, string expectedEndDelimiter)
     {
-        StringAssert.StartsWith(expectedStartDelimiter, actual);
-        StringAssert.EndsWith(expectedEndDelimiter, actual);
+        Assert.That(actual, Does.StartWith(expectedStartDelimiter));
+        Assert.That(actual, Does.EndWith(expectedEndDelimiter));
     }
 
     public static void ShouldBeSurroundedWith(this string actual, string expectedDelimiter)
     {
-        StringAssert.StartsWith(expectedDelimiter, actual);
-        StringAssert.EndsWith(expectedDelimiter, actual);
+        Assert.That(actual, Does.StartWith(expectedDelimiter));
+        Assert.That(actual, Does.EndWith(expectedDelimiter));
     }
 
     public static void ShouldContainErrorMessage(this Exception exception, string expected)
     {
-        StringAssert.Contains(expected, exception.Message);
+        Assert.That(exception.Message, Does.Contain(expected));
     }
 
     public static Exception ShouldBeThrownBy(this Type exceptionType, MethodThatThrows method)
     {
         var exception = method.GetException();
 
-        Assert.IsNotNull(exception, $"{exceptionType.Name} was not thrown");
-        Assert.AreEqual(exceptionType, exception!.GetType());
+        Assert.That(exception, Is.Not.Null, $"{exceptionType.Name} was not thrown");
+        Assert.That(exception!.GetType(), Is.EqualTo(exceptionType));
 
         return exception!;
     }
 
     public static void ShouldBeBetween(this DateTime actual, DateTime inferior, DateTime superior)
     {
-        Assert.LessOrEqual(inferior, actual);
-        Assert.GreaterOrEqual(superior, actual);
+        Assert.That(inferior, Is.LessThanOrEqualTo(actual));
+        Assert.That(superior, Is.GreaterThanOrEqualTo(actual));
     }
 
     public static Exception? GetException(this MethodThatThrows method)
@@ -347,9 +308,7 @@ internal static class NUnitExtensions
     }
 
     public static void ShouldBeOfType<T>(this object? actual)
-    {
-        Assert.IsInstanceOf<T>(actual);
-    }
+        => Assert.That(actual, Is.InstanceOf<T>());
 
     public static void ShouldHaveSamePropertiesAs(this object actual, object expected, params string[] ignoredProperties)
     {
@@ -379,17 +338,15 @@ internal static class NUnitExtensions
                 continue;
 
             if (expectedValue == null)
-                Assert.Fail("Missing field or property {0} on type {1}", actualProperty.Name, expected.GetType());
+                Assert.Fail($"Missing field or property {actualProperty.Name} on type {expected.GetType()}");
 
             if (!LooseEquals(expectedValue, actualValue))
-                Assert.Fail("{0} should be equal, found {1}, expected {2}", actualProperty.Name, actualValue, expectedValue);
+                Assert.Fail($"{actualProperty.Name} should be equal, found {actualValue}, expected {expectedValue}");
         }
     }
 
     public static void ShouldHaveSize<T>(this IEnumerable<T> enumerable, int size)
-    {
-        enumerable.Count().ShouldEqual(size, $"Collection should contain {size} items");
-    }
+        => enumerable.Count().ShouldEqual(size, $"Collection should contain {size} items");
 
     public static TSource ExpectedSingle<TSource>(this IEnumerable<TSource> source)
     {
@@ -453,18 +410,12 @@ internal static class NUnitExtensions
         private readonly Func<object?, object?, bool> _comparer;
 
         public EqualityComparer(Func<object?, object?, bool> comparer)
-        {
-            _comparer = comparer;
-        }
+            => _comparer = comparer;
 
         bool IEqualityComparer.Equals(object? x, object? y)
-        {
-            return _comparer(x, y);
-        }
+            => _comparer(x, y);
 
         public int GetHashCode(object obj)
-        {
-            return obj.GetHashCode();
-        }
+            => obj.GetHashCode();
     }
 }

--- a/src/Abc.Zebus.Tests.props
+++ b/src/Abc.Zebus.Tests.props
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
 
     <!-- This updates an older version referenced by log4net -->
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />

--- a/src/Abc.Zebus.Tests.props
+++ b/src/Abc.Zebus.Tests.props
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
 
     <!-- This updates an older version referenced by log4net -->

--- a/src/Abc.Zebus.Tests/Abc.Zebus.Tests.csproj
+++ b/src/Abc.Zebus.Tests/Abc.Zebus.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net9.0</TargetFrameworks>
     <Version>$(ZebusVersion)</Version>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Abc.Zebus.Tests/Dispatch/DispatchQueueTests.cs
+++ b/src/Abc.Zebus.Tests/Dispatch/DispatchQueueTests.cs
@@ -547,7 +547,7 @@ namespace Abc.Zebus.Tests.Dispatch
                 task.Result.Errors.ShouldBeEmpty();
         }
 
-        [Test, Timeout(5000)]
+        [Test]
         public void should_not_wait_for_all_messages_processed_when_not_started()
         {
             _dispatchQueue.WaitUntilAllMessagesAreProcessed();

--- a/src/Abc.Zebus.Tests/Transport/ZmqTransportTests.cs
+++ b/src/Abc.Zebus.Tests/Transport/ZmqTransportTests.cs
@@ -72,7 +72,7 @@ namespace Abc.Zebus.Tests.Transport
             var message = new FakeCommand(1).ToTransportMessage();
             transport1.Send(message, new[] { transport2Peer });
 
-            Wait.Until(() => transport2ReceivedMessages.Count >= 1, 2.Seconds());
+            Wait.Until(() => transport2ReceivedMessages.Count >= 1, 30.Seconds());
             transport2ReceivedMessages.Single().Id.ShouldEqual(message.Id);
         }
 
@@ -90,7 +90,7 @@ namespace Abc.Zebus.Tests.Transport
             senderTransport.Send(message, new[] { nonExistingPeer });
             senderTransport.Send(message, new[] { destinationPeer });
 
-            Wait.Until(() => receivedMessages.Count >= 1, 2.Seconds(), "The outbound thread was killed and couldn't connect to the next peer");
+            Wait.Until(() => receivedMessages.Count >= 1, 30.Seconds(), "The outbound thread was killed and couldn't connect to the next peer");
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace Abc.Zebus.Tests.Transport
             transport2.Configure(transport2Peer.Id, _environment);
             transport1.Send(message2, new[] { transport2Peer }); //should arrive
 
-            Wait.Until(() => transport2ReceivedMessages.Count >= 1, 2.Seconds());
+            Wait.Until(() => transport2ReceivedMessages.Count >= 1, 30.Seconds());
             transport2ReceivedMessages.Single().Id.ShouldEqual(message2.Id);
         }
 
@@ -129,7 +129,7 @@ namespace Abc.Zebus.Tests.Transport
             var message1 = new FakeCommand(1).ToTransportMessage();
             transport1.Send(message1, new[] { transport2Peer });
 
-            Wait.Until(() => transport2ReceivedMessages.Count == 1, 2.Seconds());
+            Wait.Until(() => transport2ReceivedMessages.Count == 1, 30.Seconds());
             var transport2ReceivedMessage = transport2ReceivedMessages.ExpectedSingle();
             transport2ReceivedMessage.ShouldHaveSamePropertiesAs(message1, "Environment", "WasPersisted");
             transport2ReceivedMessage.Environment.ShouldEqual("Test");
@@ -138,7 +138,7 @@ namespace Abc.Zebus.Tests.Transport
             var message2 = new FakeCommand(2).ToTransportMessage();
             transport2.Send(message2, new[] { transport1Peer });
 
-            Wait.Until(() => transport1ReceivedMessages.Count == 1, 2.Seconds());
+            Wait.Until(() => transport1ReceivedMessages.Count == 1, 30.Seconds());
             var transport1ReceivedMessage = transport1ReceivedMessages.ExpectedSingle();
             transport1ReceivedMessage.ShouldHaveSamePropertiesAs(message2, "Environment", "WasPersisted");
             transport1ReceivedMessage.Environment.ShouldEqual("Test");
@@ -164,13 +164,13 @@ namespace Abc.Zebus.Tests.Transport
             var message = new FakeCommand(999).ToTransportMessage();
             senderTransport.Send(message, new[] { receiverPeer }, new SendContext { PersistentPeerIds = { receiverPeer.Id }, PersistencePeer = persistencePeer });
 
-            Wait.Until(() => receiverMessages.Count == 1, 2.Seconds());
+            Wait.Until(() => receiverMessages.Count == 1, 30.Seconds());
             var messageFromReceiver = receiverMessages.ExpectedSingle();
             messageFromReceiver.ShouldHaveSamePropertiesAs(message, "Environment", "WasPersisted");
             messageFromReceiver.Environment.ShouldEqual("Test");
             messageFromReceiver.WasPersisted.ShouldEqual(true);
 
-            Wait.Until(() => persistenceMessages.Count == 1, 2.Seconds());
+            Wait.Until(() => persistenceMessages.Count == 1, 30.Seconds());
             var messageFromPersistence = persistenceMessages.ExpectedSingle();
             messageFromPersistence.ShouldHaveSamePropertiesAs(message, "Environment", "WasPersisted", "PersistentPeerIds", "IsPersistTransportMessage");
             messageFromPersistence.Environment.ShouldEqual("Test");
@@ -194,7 +194,7 @@ namespace Abc.Zebus.Tests.Transport
             var message = new FakeCommand(999).ToTransportMessage();
             senderTransport.Send(message, Enumerable.Empty<Peer>(), new SendContext { PersistentPeerIds = { receiverPeerId }, PersistencePeer = persistencePeer });
 
-            Wait.Until(() => persistenceMessages.Count == 1, 2.Seconds());
+            Wait.Until(() => persistenceMessages.Count == 1, 30.Seconds());
             var messageFromPersistence = persistenceMessages.ExpectedSingle();
             messageFromPersistence.ShouldHaveSamePropertiesAs(message, "Environment", "WasPersisted", "PersistentPeerIds", "IsPersistTransportMessage");
             messageFromPersistence.Environment.ShouldEqual("Test");
@@ -217,7 +217,7 @@ namespace Abc.Zebus.Tests.Transport
             var message = new FakeCommand(999).ToTransportMessage().ToPersistTransportMessage(receiverPeerId);
             senderTransport.Send(message, new[] { persistencePeer });
 
-            Wait.Until(() => persistenceMessages.Count == 1, 2.Seconds());
+            Wait.Until(() => persistenceMessages.Count == 1, 30.Seconds());
             var messageFromPersistence = persistenceMessages.ExpectedSingle();
             messageFromPersistence.ShouldHaveSamePropertiesAs(message, "Environment", "WasPersisted");
             messageFromPersistence.Environment.ShouldEqual("Test");
@@ -238,7 +238,7 @@ namespace Abc.Zebus.Tests.Transport
             sender.Send(message, new[] { receivingPeer }, new SendContext { PersistentPeerIds = { receivingPeer.Id } });
             sender.Send(otherMessage, new[] { receivingPeer }, new SendContext());
 
-            Wait.Until(() => receivedMessages.Count >= 2, 2.Seconds());
+            Wait.Until(() => receivedMessages.Count >= 2, 30.Seconds());
             receivedMessages.Single(x => x.Id == message.Id).WasPersisted.ShouldEqual(true);
             receivedMessages.Single(x => x.Id == otherMessage.Id).WasPersisted.ShouldEqual(false);
         }
@@ -259,7 +259,7 @@ namespace Abc.Zebus.Tests.Transport
 
             sender.Send(message, new[] { receivingPeer1, receivingPeer2 }, new SendContext { PersistentPeerIds = { receivingPeer1.Id } });
 
-            Wait.Until(() => receivedMessages.Count >= 2, 2.Seconds());
+            Wait.Until(() => receivedMessages.Count >= 2, 30.Seconds());
             receivedMessages.ShouldContain(x => x.Id == message.Id && x.WasPersisted == true);
             receivedMessages.ShouldContain(x => x.Id == message.Id && x.WasPersisted == false);
         }
@@ -275,13 +275,13 @@ namespace Abc.Zebus.Tests.Transport
             var receiver = receiverTransport1.GetPeer();
 
             senderTransport.Send(new FakeCommand(0).ToTransportMessage(), new[] { receiver });
-            Wait.Until(() => receivedMessages.Count == 1, 2.Seconds());
+            Wait.Until(() => receivedMessages.Count == 1, 30.Seconds());
 
             receiverTransport1.Stop();
             receiver.EndPoint = receiverTransport2.InboundEndPoint;
 
             senderTransport.Send(new FakeCommand(0).ToTransportMessage(), new[] { receiver });
-            Wait.Until(() => receivedMessages.Count == 2, 2.Seconds(), "unable to receive message");
+            Wait.Until(() => receivedMessages.Count == 2, 30.Seconds(), "unable to receive message");
         }
 
         [Test]
@@ -301,7 +301,7 @@ namespace Abc.Zebus.Tests.Transport
 
             var message = new FakeCommand(1).ToTransportMessage();
             senderTransport.Send(message, new[] { receiverPeer });
-            Wait.Until(() => senderTransport.OutboundSocketCount == 1, 2.Seconds());
+            Wait.Until(() => senderTransport.OutboundSocketCount == 1, 30.Seconds());
 
             senderTransport.OnPeerUpdated(receiverPeer.Id, PeerUpdateAction.Decommissioned);
 
@@ -311,7 +311,7 @@ namespace Abc.Zebus.Tests.Transport
 
             using (SystemDateTime.PauseTime(SystemDateTime.UtcNow.Add(30.Seconds())))
             {
-                Wait.Until(() => senderTransport.OutboundSocketCount == 0, 1.Seconds(), "Socket should be disconnected");
+                Wait.Until(() => senderTransport.OutboundSocketCount == 0, 30.Seconds(), "Socket should be disconnected");
             }
         }
 
@@ -324,11 +324,11 @@ namespace Abc.Zebus.Tests.Transport
 
             var message = new FakeCommand(1).ToTransportMessage();
             senderTransport.Send(message, new[] { receiverPeer });
-            Wait.Until(() => senderTransport.OutboundSocketCount == 1, 2.Seconds());
+            Wait.Until(() => senderTransport.OutboundSocketCount == 1, 30.Seconds());
 
             senderTransport.OnPeerUpdated(receiverPeer.Id, PeerUpdateAction.Started);
 
-            Wait.Until(() => senderTransport.OutboundSocketCount == 0, 2.Seconds(), "Socket should be disconnected");
+            Wait.Until(() => senderTransport.OutboundSocketCount == 0, 30.Seconds(), "Socket should be disconnected");
         }
 
         [Test]
@@ -346,7 +346,7 @@ namespace Abc.Zebus.Tests.Transport
                 senderTransport.Send(message, new[] { receiver });
             }
 
-            Wait.Until(() => receivedMessages.Count == 10, 1.Second());
+            Wait.Until(() => receivedMessages.Count == 10, 30.Seconds());
 
             for (var i = 0; i < 10; ++i)
             {
@@ -375,7 +375,7 @@ namespace Abc.Zebus.Tests.Transport
             var message = new FakeCommand(999).ToTransportMessage();
             senderTransport.Send(message, receiverTransports.Select(x => x.GetPeer()));
 
-            Wait.Until(() => Volatile.Read(ref receivedMessagesCount) == peerCount, 30.Second());
+            Wait.Until(() => Volatile.Read(ref receivedMessagesCount) == peerCount, 30.Seconds());
         }
 
         [Test]
@@ -399,7 +399,7 @@ namespace Abc.Zebus.Tests.Transport
             var message = new FakeCommand(999).ToTransportMessage();
             senderTransport.Send(message, receiverTransports.Select(x => x.GetPeer()));
 
-            Wait.Until(() => receivedMessages.Count == maximumSocketCount - 1, 10.Seconds());
+            Wait.Until(() => receivedMessages.Count == maximumSocketCount - 1, 30.Seconds());
 
             Thread.Sleep(1.Second());
 
@@ -431,7 +431,7 @@ namespace Abc.Zebus.Tests.Transport
                 senderTransport.Send(message, new[] { upReceiver, downReceiver });
 
                 var expectedMessageCount = i;
-                Wait.Until(() => receivedMessages.Count == expectedMessageCount, 2.Seconds(), "Failed to send message after " + i + " successful sent");
+                Wait.Until(() => receivedMessages.Count == expectedMessageCount, 30.Seconds(), "Failed to send message after " + i + " successful sent");
             }
         }
 
@@ -467,7 +467,7 @@ namespace Abc.Zebus.Tests.Transport
             }
 
             var receiverStopwatch = Stopwatch.StartNew();
-            Wait.Until(() => receivedMessages.Count == 10, 10.Seconds(), "Timed out while waiting for messages");
+            Wait.Until(() => receivedMessages.Count == 10, 30.Seconds(), "Timed out while waiting for messages");
             receiverStopwatch.Stop();
             Console.WriteLine("Elapsed time to get messages: " + receiverStopwatch.Elapsed);
             receiverStopwatch.ElapsedMilliseconds.ShouldBeLessOrEqualThan(1000, "Throughput is too low");
@@ -488,7 +488,7 @@ namespace Abc.Zebus.Tests.Transport
                 senderTransport.Send(message, new[] { invalidPeer, receiver });
             }
 
-            Wait.Until(() => receivedMessageCount == 1000, 5.Seconds());
+            Wait.Until(() => receivedMessageCount == 1000, 30.Seconds());
         }
 
         [Test]
@@ -509,14 +509,14 @@ namespace Abc.Zebus.Tests.Transport
             var bigMessage = new TransportMessage(new MessageTypeId(typeof(FakeCommand)), messageBytes, new PeerId("X"), senderTransport.InboundEndPoint);
             senderTransport.Send(bigMessage, new[] { receiver });
 
-            Wait.Until(() => receivedMessages.Count == 1, 2.Seconds());
+            Wait.Until(() => receivedMessages.Count == 1, 30.Seconds());
 
             receivedMessages[0].ShouldHaveSamePropertiesAs(bigMessage, "Environment", "WasPersisted");
 
             var smallMessage = new TransportMessage(new MessageTypeId(typeof(FakeCommand)), new byte[1], new PeerId("X"), senderTransport.InboundEndPoint);
             senderTransport.Send(smallMessage, new[] { receiver });
 
-            Wait.Until(() => receivedMessages.Count == 2, 2.Seconds());
+            Wait.Until(() => receivedMessages.Count == 2, 30.Seconds());
 
             receivedMessages[1].ShouldHaveSamePropertiesAs(smallMessage, "Environment", "WasPersisted");
         }
@@ -530,7 +530,7 @@ namespace Abc.Zebus.Tests.Transport
 
             transport.Send(new FakeCommand(1).ToTransportMessage(), new[] { self });
 
-            Wait.Until(() => receivedMessages.Count == 1, 2.Seconds());
+            Wait.Until(() => receivedMessages.Count == 1, 30.Seconds());
         }
 
         [Test]
@@ -560,7 +560,7 @@ namespace Abc.Zebus.Tests.Transport
                 Console.WriteLine($"{sendCount} messages sent");
             });
 
-            Wait.Until(() => receivedMessages.Count > 1, 10.Seconds());
+            Wait.Until(() => receivedMessages.Count > 1, 30.Seconds());
             Console.WriteLine("Message received");
 
             receivingTransport.Stop();
@@ -601,7 +601,7 @@ namespace Abc.Zebus.Tests.Transport
             });
 
             senderTask.Start();
-            Wait.Until(() => receivedMessageCount != 0, 2.Seconds());
+            Wait.Until(() => receivedMessageCount != 0, 30.Seconds());
 
             Log($"Stopping the sender");
             shouldSend[0] = false;
@@ -631,12 +631,12 @@ namespace Abc.Zebus.Tests.Transport
 
             transport1.Send(new FakeCommand(0).ToTransportMessage(), new[] { peer2 });
             transport2.Send(new FakeCommand(0).ToTransportMessage(), new[] { peer1 });
-            Wait.Until(() => transport1.OutboundSocketCount == 1, 10.Seconds());
-            Wait.Until(() => transport2.OutboundSocketCount == 1, 10.Seconds());
+            Wait.Until(() => transport1.OutboundSocketCount == 1, 30.Seconds());
+            Wait.Until(() => transport2.OutboundSocketCount == 1, 30.Seconds());
 
             transport2.Stop();
 
-            Wait.Until(() => transport1.OutboundSocketCount == 0, 10.Seconds());
+            Wait.Until(() => transport1.OutboundSocketCount == 0, 30.Seconds());
         }
 
         private ZmqTransport CreateZmqTransport(string endPoint = "tcp://*:*", Action<TransportMessage> onMessageReceived = null, string peerId = null, string environment = _environment, ZmqSocketOptions socketOptions = null)

--- a/src/Abc.Zebus.Tests/Transport/ZmqTransportTests.cs
+++ b/src/Abc.Zebus.Tests/Transport/ZmqTransportTests.cs
@@ -355,7 +355,6 @@ namespace Abc.Zebus.Tests.Transport
             }
         }
 
-        [Timeout(10 * 60 * 1000)]
         [TestCase(10)]
         [TestCase(25)]
         // Cases with high peer counts are too slow to run automatically, but they are required to validate edge cases.

--- a/src/Abc.Zebus.Tests/Util/Extensions/ExtendICollectionTests.cs
+++ b/src/Abc.Zebus.Tests/Util/Extensions/ExtendICollectionTests.cs
@@ -21,8 +21,8 @@ namespace Abc.Zebus.Tests.Util.Extensions
             ICollection<int> collection = new[] { 1, 2, 3 }.ToList();
             var returned = collection.AddRange(new[] { 4, 5 });
 
-            Assert.AreSame(collection, returned);
-            CollectionAssert.AreEquivalent(collection, new[] { 1, 2, 3, 4, 5 });
+            Assert.That(returned, Is.SameAs(collection));
+            Assert.That(new[] { 1, 2, 3, 4, 5 }, Is.EquivalentTo(collection));
         }
 
         [Test]
@@ -31,8 +31,8 @@ namespace Abc.Zebus.Tests.Util.Extensions
             ICollection<int> collection = new[] { 1, 2, 3 }.ToList();
             var returned = collection.RemoveRange(new[] { 1, 4 });
 
-            Assert.AreSame(collection, returned);
-            CollectionAssert.AreEquivalent(collection, new[] { 2, 3 });
+            Assert.That(returned, Is.SameAs(collection));
+            Assert.That(new[] { 2, 3 }, Is.EquivalentTo(collection));
         }
     }
 }


### PR DESCRIPTION
I'm not sure how we should update the Zebus.Testing library version... Currently we have `<ZebusTestingVersion>$(ZebusVersion)</ZebusTestingVersion>`, which Zebus.Testing version should we release next?

- 4.0.0: it wouldn't be nice to have a different major than the main lib, but we bumped a dependency major version
- 3.15.0: there is no associated Zebus version yet
- 3.15.0-pre1: just a prerelease for the moment, but only Zebus.Testing changed

Thoughts?
